### PR TITLE
implement abstract keycodes

### DIFF
--- a/src/base.ml
+++ b/src/base.ml
@@ -1,7 +1,12 @@
 (* open Graphics *)
 open Tsdl
 
-module KeyCodeSet = Set.Make(Int)
+module KeyCodeSet = Set.Make(struct
+  type t = Key.t
+  let compare = compare
+end)
+
+module PlatformKey = KeySDL
 
 type boot_func = Screen.t -> Framebuffer.t
 type tick_func = int -> Screen.t -> Framebuffer.t -> KeyCodeSet.t -> Framebuffer.t
@@ -94,8 +99,12 @@ let run (title : string) (boot : boot_func option) (tick : tick_func) (s : Scree
           | true -> (
             match Sdl.Event.(enum (get e typ)) with
             | `Quit -> (true, keys)
-            | `Key_down -> (false, KeyCodeSet.add Sdl.Event.(get e keyboard_keycode) keys)
-            | `Key_up -> (false, KeyCodeSet.remove Sdl.Event.(get e keyboard_keycode) keys)
+            | `Key_down -> 
+                let key = PlatformKey.of_backend_keycode (Sdl.Event.(get e keyboard_keycode)) in
+                (false, KeyCodeSet.add key keys)
+            | `Key_up -> 
+              let key = PlatformKey.of_backend_keycode (Sdl.Event.(get e keyboard_keycode)) in
+              (false, KeyCodeSet.remove key keys)
             | _ -> (false, keys)
           )
           | false -> (false, keys) in

--- a/src/base.mli
+++ b/src/base.mli
@@ -1,6 +1,5 @@
 (** Main Claudius entry point. *)
-
-module KeyCodeSet : Set.S with type elt = int
+module KeyCodeSet : Set.S with type elt = Key.t
 
 type boot_func = Screen.t -> Framebuffer.t
 (** Function called once a start of run *)

--- a/src/key.ml
+++ b/src/key.ml
@@ -1,0 +1,8 @@
+type t =
+  | Left
+  | Right
+  | Up
+  | Down
+  | Space
+  | Escape
+  | Unknown

--- a/src/key_sdl.ml
+++ b/src/key_sdl.ml
@@ -1,0 +1,22 @@
+(* sdl keycodes *)
+module KeySDL = struct
+  let of_backend_keycode (keycode: int) : Key.t =
+    match keycode with
+    | 0x4000004F -> Key.Right
+    | 0x40000050 -> Key.Left
+    | 0x40000051 -> Key.Down
+    | 0x40000052 -> Key.Up
+    | 0x00000020 -> Key.Space
+    | 0x0000001B -> Key.Escape
+    | _ -> Key.Unknown
+
+  let to_backend_keycode (key: Key.t) : int =
+    match key with
+    | Key.Right -> 0x4000004F
+    | Key.Left -> 0x40000050
+    | Key.Down -> 0x40000051
+    | Key.Up -> 0x40000052
+    | Key.Space -> 0x00000020
+    | Key.Escape -> 0x0000001B
+    | Key.Unknown -> -1
+end

--- a/src/key_sdl.mli
+++ b/src/key_sdl.mli
@@ -1,0 +1,4 @@
+module KeySDL : sig
+  val of_backend_keycode : int -> Key.t
+  val to_backend_keycode : Key.t -> int
+end


### PR DESCRIPTION
Hi @mdales,

Here's my approach towards this:

- `KeyCodeSet` now stores `Key.t` instead of raw integers, making key handling more readable and independent of backend-specific codes.
- Each platform will now have its own module that maps platform-specific keycodes to a generic `Key.t` type.
- The example will change to use `Base.PlatformKey.[Right, Left, Up, Down, etc.]`, making it clearer and more portable.
- Backends can now be swapped easily by selecting the appropriate module, removing the dependency on SDL key codes in game logic.

Please let me know if I'm moving in the right direction! 