### PR TITLE
Optimised framebuffer updates in correspondence with the requested changes

### DIFF
--- a/src/base.ml
+++ b/src/base.ml
@@ -94,6 +94,12 @@ let run (title : string) (boot : boot_func option) (tick : tick_func) (s : Scree
           match render_texture r texture s bitmap with
           | Error (`Msg e) -> Sdl.log "Boot error: %s" e
           | Ok () -> ()
+        ) else if Framebuffer.is_dirty updated_buffer then (
+          framebuffer_to_bigarray s updated_buffer bitmap;
+          match render_texture r texture s bitmap with
+          | Error (`Msg e) -> Sdl.log "Boot error: %s" e
+          | Ok () -> ();
+          Framebuffer.clear_dirty updated_buffer
         );
 
         let exit, keys =

--- a/src/framebuffer.ml
+++ b/src/framebuffer.ml
@@ -10,30 +10,31 @@ let to_array (buffer : t) : int array array =
 let init (dimensions : int * int) (f : int -> int -> int) : t =
   let width, height = dimensions in
   if width <= 0 then raise (Invalid_argument "Invalid width");
-  if height <= 0 then raise (Invalid_argument "Invalid height");
+  if height <= 0 then raise (Invalid_argument "Invalid height");  
   { data = Array.init height (fun y ->
-    Array.init width (fun x ->
+      Array.init width (fun x ->
         f x y
       )
-  );
+    );
     dirty = true }
 
 let pixel_write (x : int) (y : int) (col : int) (buffer : t) =
-  if (x >= 0) && (x < Array.length (buffer.data.(0))) && (y >= 0) && (y < Array.length buffer.data) then
+  if (x >= 0) && (x < Array.length (buffer.data.(0)))
+     && (y >= 0) && (y < Array.length buffer.data) then (
     buffer.data.(y).(x) <- col;
-  buffer.dirty <- true
+    buffer.dirty <- true
+  )
 
 let pixel_read (x : int) (y : int) (buffer : t) : int option =
-  if (x >= 0) && (x < Array.length (buffer.data.(0))) && (y >= 0) && (y < Array.length buffer.data) then
+  if (x >= 0) && (x < Array.length (buffer.data.(0)))
+     && (y >= 0) && (y < Array.length buffer.data) then
     Some buffer.data.(y).(x)
   else
     None
 
 let draw_circle (x : int) (y : int) (r : float) (col : int) (buffer : t) =
-  buffer.dirty <- true;
   let fx = Float.of_int x
   and fy = Float.of_int y in
-
   for yo = 0 to (Int.of_float (r *. sin (Float.pi *. 0.25))) do
     let yi = y + yo in
     let a = acos ((Float.of_int (yi - y)) /. r) in
@@ -48,12 +49,11 @@ let draw_circle (x : int) (y : int) (r : float) (col : int) (buffer : t) =
     pixel_write (x - yo) (Int.of_float (fy -. xw)) col buffer;
     pixel_write (x + yo) (Int.of_float (fy +. xw)) col buffer;
     pixel_write (x - yo) (Int.of_float (fy +. xw)) col buffer;
-
   done
 
 let filled_circle (x : int) (y : int) (r : float) (col : int) (buffer : t) =
-  buffer.dirty <- true;
-  let fx = Float.of_int x and fy = Float.of_int y in
+  let fx = Float.of_int x
+  and fy = Float.of_int y in
   let my = Float.of_int ((Array.length buffer.data) - 1)
   and mx = Float.of_int ((Array.length buffer.data.(0)) - 1) in
   let pminy = fy -. r
@@ -61,74 +61,63 @@ let filled_circle (x : int) (y : int) (r : float) (col : int) (buffer : t) =
   let miny = if (pminy < 0.) then 0. else pminy
   and maxy = if (pmaxy > my) then my else pmaxy in
   for yi = (Int.of_float miny) to (Int.of_float maxy) do
-    let row = buffer.data.(yi) in
     let a = acos ((Float.of_int (yi - y)) /. r) in
     let xw = (sin a) *. r in
     let pminx = fx -. xw
     and pmaxx = fx +. xw in
     let minx = if (pminx < 0.) then 0. else pminx
     and maxx = if (pmaxx > mx) then mx else pmaxx in
-    if (maxx > 0.0) && (minx < mx) then
-      for xi = (Int.of_float minx) to (Int.of_float maxx) do
-        row.(xi) <- col
-      done
+    for xi = (Int.of_float minx) to (Int.of_float maxx) do
+      pixel_write xi yi col buffer
+    done
   done
 
 let draw_line (x0 : int) (y0 : int) (x1 : int) (y1 : int) (col : int) (buffer : t) =
-  buffer.dirty <- true;
   let dx = abs (x1 - x0)
   and sx = if x0 < x1 then 1 else -1
   and dy = (abs (y1 - y0)) * -1
   and sy = if y0 < y1 then 1 else -1 in
   let initial_error = dx + dy in
-
   let rec loop (x : int) (y : int) (error : int) =
-    if (x >= 0) && (x < Array.length (buffer.data.(0))) && (y >= 0) && (y < Array.length buffer.data) then
-      buffer.data.(y).(x) <- col;
-    match (x == x1) && (y == y1) with
-    | true -> ()
-    | false -> (
+    pixel_write x y col buffer;
+    if (x = x1) && (y = y1) then ()
+    else begin
       let e2 = 2 * error in
-      let nx = match e2 >= dy with
-      | false -> x
-      | true -> x + sx in
-      let ny = match e2 <= dx with
-      | false -> y
-      | true -> y + sy in
-      let nex = match (e2 >= dy) with
-      | false -> 0
-      | true -> dy in
-      let ney = match (e2 <= dx) with
-      | false -> 0
-      | true -> dx in
+      let nx = if e2 >= dy then x + sx else x in
+      let ny = if e2 <= dx then y + sy else y in
+      let nex = if e2 >= dy then dy else 0 in
+      let ney = if e2 <= dx then dx else 0 in
       loop nx ny (error + nex + ney)
-    )
-  in loop x0 y0 initial_error
+    end
+  in
+  loop x0 y0 initial_error
+
 
 let draw_polygon (points : (int * int) list) (col : int) (buffer : t) =
-  buffer.dirty <- true;
   match points with
   | [] -> ()
-  | hd :: tl -> (
+  | hd :: tl ->
     let rec loop start prev rest =
       let x0, y0 = prev in
       match rest with
       | [] -> ()
-      | ihd :: [] -> (
+      | ihd :: [] ->
         let x1, y1 = ihd in
         draw_line x0 y0 x1 y1 col buffer;
         let xs, ys = start in
         draw_line x1 y1 xs ys col buffer;
-      )
-      | ihd :: itl -> (
+      | ihd :: itl ->
         let x1, y1 = ihd in
         draw_line x0 y0 x1 y1 col buffer;
         loop start ihd itl
-      ) in loop hd hd tl
-  )
+    in
+    loop hd hd tl
 
 let draw_rect (x : int) (y : int) (width : int) (height : int) (col : int) (buffer : t) =
-  draw_polygon [ (x, y) ; (x + width, y) ; (x + width, y + height) ; (x , y + height)] col buffer
+  draw_polygon [ (x, y);
+                 (x + width, y);
+                 (x + width, y + height);
+                 (x, y + height) ] col buffer
 
 let filled_rect (x : int) (y : int) (width : int) (height : int) (col : int) (buffer : t) =
   for oy = 0 to height do
@@ -141,8 +130,8 @@ let draw_triangle (x0 : int) (y0 : int) (x1 : int) (y1 : int) (x2 : int) (y2 : i
   draw_line x2 y2 x0 y0 col buffer
 
 type span =
-| Only of int
-| Pair of int * int
+  | Only of int
+  | Pair of int * int
 
 let interpolate_line (x0 : int) (y0 : int) (x1 : int) (y1 : int) : span array =
   let dx = abs (x1 - x0)
@@ -150,93 +139,81 @@ let interpolate_line (x0 : int) (y0 : int) (x1 : int) (y1 : int) : span array =
   and dy = (abs (y1 - y0)) * -1
   and sy = if y0 <= y1 then 1 else -1 in
   let initial_error = dx + dy in
-
-  let result : span option array = Array.init (abs (y1 - y0) + 1) (fun _i -> None) in
+  let result : span option array = Array.init (abs (y1 - y0) + 1) (fun _ -> None) in
   result.(0) <- Some (Only x0);
-
   let rec loop (x : int) (y : int) (error : int) =
-    match (x == x1) && (y == y1) with
-    | true -> ()
-    | false -> (
+    if (x = x1) && (y = y1) then ()
+    else begin
       let e2 = 2 * error in
-      let nx = match e2 >= dy with
-      | false -> x
-      | true -> x + sx in
-      let ny = match e2 <= dx with
-      | false -> y
-      | true -> y + sy in
-      let nex = match (e2 >= dy) with
-      | false -> 0
-      | true -> dy in
-      let ney = match (e2 <= dx) with
-      | false -> 0
-      | true -> dx in
+      let nx = if e2 >= dy then x + sx else x in
+      let ny = if e2 <= dx then y + sy else y in
+      let nex = if e2 >= dy then dy else 0 in
+      let ney = if e2 <= dx then dx else 0 in
       let index = ny - (y0 * sy) in
       result.(index) <- (
         match result.(index) with
         | None -> Some (Only nx)
-        | Some span -> Some (
-          match span with
-          | Only (a) -> (if a == nx then Only(a) else (if (a > nx) then Pair(nx, a) else (Pair(a, nx))))
-          | Pair (a, b) -> (if nx <= a then Pair(nx, b) else Pair(a, nx))
-        )
+        | Some span ->
+          Some (
+            match span with
+            | Only a ->
+              if a = nx then Only a
+              else if a > nx then Pair (nx, a)
+              else Pair (a, nx)
+            | Pair (a, b) ->
+              if nx <= a then Pair (nx, b)
+              else Pair (a, nx)
+          )
       );
       loop nx ny (error + nex + ney)
-    )
-  in loop x0 y0 initial_error;
-  Array.map (fun maybe_span ->
-    match maybe_span with
+    end
+  in
+  loop x0 y0 initial_error;
+  Array.map (function
     | None -> assert false
-    | Some (span) -> span
+    | Some span -> span
   ) result
 
 let leftmost span =
   match span with
-  | Only (x) -> x
+  | Only x -> x
   | Pair (x0, _) -> x0
 
 let rightmost span =
   match span with
-  | Only (x) -> x
+  | Only x -> x
   | Pair (_, x1) -> x1
 
 let filled_triangle (x0 : int) (y0 : int) (x1 : int) (y1 : int) (x2 : int) (y2 : int) (col : int) (buffer : t) =
-  buffer.dirty <- true;
-  let points = [(x0, y0) ; (x1, y1) ; (x2, y2)] in
-  let sorted_points = List.sort (fun a b ->
-    let _, ay = a and _, by = b in
-    ay - by
-  ) points in
+  let points = [(x0, y0); (x1, y1); (x2, y2)] in
+  let sorted_points = List.sort (fun (,ay) (,by) -> ay - by) points in
   let x0, y0 = List.nth sorted_points 0
   and x1, y1 = List.nth sorted_points 1
   and x2, y2 = List.nth sorted_points 2 in
-
   let long_edge = interpolate_line x0 y0 x2 y2 in
-
-  let other_edge = if (y1 == y0) then (
-    interpolate_line x1 y1 x2 y2
-  ) else if (y1 == y2) then (
-    interpolate_line x0 y0 x1 y1
-  ) else (
-    let s1 = interpolate_line x0 y0 x1 y1
-    and s2 = interpolate_line x1 y1 x2 y2 in
-    Array.concat [s1 ; (Array.sub s2 1 ((Array.length s2) - 1))]
-  ) in
-  assert ((Array.length long_edge) == (Array.length other_edge));
-
+  let other_edge =
+    if (y1 = y0) then
+      interpolate_line x1 y1 x2 y2
+    else if (y1 = y2) then
+      interpolate_line x0 y0 x1 y1
+    else
+      let s1 = interpolate_line x0 y0 x1 y1
+      and s2 = interpolate_line x1 y1 x2 y2 in
+      Array.concat [ s1; Array.sub s2 1 (Array.length s2 - 1) ]
+  in
+  assert (Array.length long_edge = Array.length other_edge);
   let spans = Array.map2 (fun a b -> (a, b)) long_edge other_edge in
-  Array.iteri (fun i s ->
+  Array.iteri (fun i (p, q) ->
     let index = y0 + i in
     if (index >= 0) && (index < Array.length buffer.data) then (
-      let row = buffer.data.(y0 + i) in
-      let stride = Array.length row in
-      let p, q = s in
-      let p0, p1 = if (leftmost p <= leftmost q) then p, q else q, p in
+      let p0, p1 = if leftmost p <= leftmost q then p, q else q, p in
       let r0, r1 = leftmost p0, rightmost p1 in
-      if ((r1 > 0) && (r0 < (stride - 1))) then (
-        let x0 = if (r0 < 0) then 0 else (if (r0 >= stride) then (stride - 1) else r0)
-        and x1 = if (r1 < 0) then 0 else (if (r1 >= stride) then (stride - 1) else r1) in
-        Array.fill row x0 ((x1 - x0) + 1) col
+      if (r1 >= 0) && (r0 < Array.length buffer.data.(index)) then (
+        let xstart = max 0 r0 in
+        let xend   = min (Array.length buffer.data.(index) - 1) r1 in
+        for x = xstart to xend do
+          pixel_write x index col buffer
+        done
       )
     )
   ) spans
@@ -244,14 +221,12 @@ let filled_triangle (x0 : int) (y0 : int) (x1 : int) (y1 : int) (x2 : int) (y2 :
 type strand = ((int * int) * (int * int)) list
 
 let strand_direction (s : strand) : int =
-  List.fold_right (fun a acc ->
+  List.fold_right (fun (p0, p1) acc ->
     match acc with
-    | 0 -> (
-      let p0, p1 = a in
-      let _, y0 = p0 and _, y1 = p1 in
+    | 0 ->
+      let (, y0) = p0 and (, y1) = p1 in
       let diff = y1 - y0 in
-      if (diff = 0) then 0 else (diff / abs(diff))
-    )
+      if diff = 0 then 0 else (diff / abs diff)
     | x -> x
   ) s 0
 
@@ -280,252 +255,242 @@ let points_to_lines points =
 let poly_to_strands (points : (int * int) list) : strand list =
   match points with
   | [] | [_] -> []
-  (* | p1 :: p2 :: ptl -> ( *)
-  | points -> (
-
-    (* let rec point_list_to_lines p1 p2 pl acc =
-      match pl with
-      | [] -> (p1, p2) :: acc
-      | np :: tl -> point_list_to_lines p2 np tl ((p1, p2) :: acc)
-    in
-    let lines = point_list_to_lines p1 p2 ptl [] in *)
+  | points ->
     let lines = Utils.points_to_lines points in
-
-    let rec loop
-        (last_direction : int)
-        (current_strand : strand)
-        (result: strand list)
-        (remaining : ((int * int) * (int * int)) list)
-        : strand list =
+    let rec loop last_direction current_strand result remaining =
       match remaining with
-      | [] -> (match current_strand with
-        | [] -> result
-        | x -> (x :: result)
-      )
-      | hd :: tl -> (
+      | [] ->
+        (match current_strand with
+         | [] -> result
+         | x -> x :: result)
+      | hd :: tl ->
         let p0, p1 = hd in
-        let _, y0 = p0 and _, y1 = p1 in
+        let (, y0) = p0 and (, y1) = p1 in
         let diff = y1 - y0 in
-        let direction = if (diff = 0) then 0 else (diff / abs(diff)) in
-        if direction == 0 then (
+        let direction = if diff = 0 then 0 else (diff / abs diff) in
+        if direction = 0 then
           loop last_direction (hd :: current_strand) result tl
-        ) else (
-          if (direction == last_direction) then (
-            loop direction (hd :: current_strand) result tl
-          ) else (
-            loop direction [hd] (current_strand :: result) tl
-          )
-        )
-      )
+        else if direction = last_direction then
+          loop direction (hd :: current_strand) result tl
+        else
+          loop direction [hd] (current_strand :: result) tl
     in
     let raw = loop 0 [] [] lines in
-    let unwrapped = List.filter (fun x -> (List.length x) > 0) raw in
-    if (List.length unwrapped) < 2 then unwrapped else (
+    let unwrapped = List.filter (fun x -> List.length x > 0) raw in
+    if List.length unwrapped < 2 then unwrapped
+    else
       let head_dir = strand_direction (List.hd unwrapped)
-      and end_dir = strand_direction (List.hd (List.rev unwrapped)) in
-      if head_dir != end_dir then unwrapped else (
+      and end_dir  = strand_direction (List.hd (List.rev unwrapped)) in
+      if head_dir <> end_dir then unwrapped
+      else
         let fore = List.hd unwrapped
         and shortened = List.tl unwrapped in
         let rev_shorted = List.rev shortened in
         let hd = List.hd rev_shorted in
         let rest = List.tl rev_shorted in
-        (List.concat [fore ; hd]) :: rest
-      )
-    )
-  )
+        (List.concat [fore; hd]) :: rest
 
 let interpolate_strand (strand : ((int * int) * (int * int)) list) : (int * span array) =
-  let spans = List.map (fun line ->
-    let p0, p1 = line in
+  let spans = List.map (fun (p0, p1) ->
     let x0, y0 = p0 and x1, y1 = p1 in
     if y0 <= y1 then
       (y0, interpolate_line x0 y0 x1 y1)
     else
       (y1, interpolate_line x1 y1 x0 y0)
   ) strand in
-  let sorted_spans = List.sort (fun a b ->
-    let y0, _ = a and y1, _ = b in y0 - y1
-  ) spans in
+  let sorted_spans = List.sort (fun (y0,) (y1,) -> y0 - y1) spans in
   match sorted_spans with
   | [] -> (0, [||])
-  | hd :: [] -> hd
-  | hd :: tl -> (
-    let y0, first_span = hd in
-    let rest = List.map (fun x ->
-      let _, spans = x in
-      Array.sub spans 1 ((Array.length spans) - 1)
-    ) tl in
-    y0, Array.concat (first_span :: rest)
-  )
+  | [y, arr] -> (y, arr)
+  | (y, first_span) :: tl ->
+    let rest = List.map (fun (_, sp) -> Array.sub sp 1 (Array.length sp - 1)) tl in
+    (y, Array.concat (first_span :: rest))
 
 let filled_polygon (points : (int * int) list) (col : int) (buffer : t) =
-  buffer.dirty <- true;
   match points with
   | [] | [_] -> ()
-  | _ -> (
-    let sorted_points = List.sort (fun a b ->
-      let _, ay = a and _, by = b in
-      ay - by
-    ) points in
-    let _, min_y = List.hd sorted_points
-    and _, max_y = List.hd (List.rev sorted_points) in
+  | _ ->
+    let sorted_points = List.sort (fun (,ay) (,by) -> ay - by) points in
+    let (_, min_y) = List.hd sorted_points
+    and (_, max_y) = List.hd (List.rev sorted_points) in
     let strands = poly_to_strands points in
     let rendered_strands = List.map interpolate_strand strands in
-
-    let map = Array.init ((max_y - min_y) + 1) (fun _i -> []) in
-    List.iter (fun l ->
-      let y, points = l in
+    let map = Array.init ((max_y - min_y) + 1) (fun _ -> []) in
+    List.iter (fun (base_y, spans) ->
       Array.iteri (fun i span ->
-        let index = (y + i) - min_y in
+        let index = (base_y + i) - min_y in
         map.(index) <- span :: map.(index)
-      ) points
+      ) spans
     ) rendered_strands;
-
-    let height = Array.length buffer in
-    Array.iteri (fun i row ->
+    let height = Array.length buffer.data in
+    Array.iteri (fun i row_spans ->
       let index = min_y + i in
-      if ((index >= 0) && (index < height)) then (
-
-        let brow = buffer.(index) in
-        let stride = Array.length brow in
-        let sorted_row = List.sort (fun a b -> (leftmost a) - (leftmost b)) row in
-
+      if (index >= 0) && (index < height) then (
+        let row = buffer.data.(index) in
+        let stride = Array.length row in
+        let sorted_row = List.sort (fun a b -> (leftmost a) - (leftmost b)) row_spans in
         let rec loop pairs =
           match pairs with
           | [] -> ()
-          | raw_x0 :: [] -> (
-            match raw_x0 with
-            | Only (x) -> (
-              let x0 = if (x < 0) then 0 else (if (x >= stride) then (stride - 1) else x) in
-              Array.fill brow x0 1 col;
-            )
-            | Pair (raw_x0, raw_x1) -> (
-              let x0 = if (raw_x0 < 0) then 0 else (if (raw_x0 >= stride) then (stride - 1) else raw_x0)
-              and x1 = if (raw_x1 < 0) then 0 else (if (raw_x1 >= stride) then (stride - 1) else raw_x1) in
-              let dist = (x1 - x0) + 1 in
-              Array.fill brow x0 dist col;
-            )
-          )
-          | raw_x0 :: raw_x1 :: tl -> (
-            let rx0 = leftmost raw_x0
-            and rx1 = rightmost raw_x1 in
-            if ((rx1 > 0) && (rx0 < (stride - 1))) then (
-              let x0 = if (rx0 < 0) then 0 else (if (rx0 >= stride) then (stride - 1) else rx0)
-              and x1 = if (rx1 < 0) then 0 else (if (rx1 >= stride) then (stride - 1) else rx1) in
-              let dist = (x1 - x0) + 1 in
-              Array.fill brow x0 dist col;
-            );
-            loop tl
-          )
-        in loop sorted_row
+          | [one_span] ->
+            (match one_span with
+             | Only x ->
+               let x0 = max 0 (min (stride - 1) x) in
+               pixel_write x0 index col buffer
+             | Pair (raw_x0, raw_x1) ->
+               let x0 = max 0 (min (stride - 1) raw_x0)
+               and x1 = max 0 (min (stride - 1) raw_x1) in
+               for x = x0 to x1 do
+                 pixel_write x index col buffer
+               done)
+          | span_a :: span_b :: rest ->
+            let rx0 = leftmost span_a
+            and rx1 = rightmost span_b in
+            let clipped_x0 = max 0 (min (stride - 1) rx0)
+            and clipped_x1 = max 0 (min (stride - 1) rx1) in
+            for x = clipped_x0 to clipped_x1 do
+              pixel_write x index col buffer
+            done;
+            loop rest
+        in
+        loop sorted_row
       )
     ) map
-  )
 
 (* ----- *)
 
 let draw_char (x : int) (y : int) (f : Font.t) (c : char) (col : int) (buffer : t) : int =
-  buffer.dirty <- true;
   match Font.glyph_of_char f (Uchar.of_char c) with
   | None -> 0
-  | Some glyph -> (
+  | Some glyph ->
     let gw, gh, _, _ = Font.Glyph.dimensions glyph in
     let bmp = Font.Glyph.bitmap glyph in
-    let bytes_per_line = (Bytes.length bmp) / gh in
-    for h = 0 to (gh - 1) do
-      for w = 0 to (bytes_per_line - 1) do
-        let bitcount = if (((w + 1) * 8) < gw) then 8 else ((gw - (w * 8)) mod 8) in
+    let bytes_per_line = Bytes.length bmp / gh in
+    for h = 0 to gh - 1 do
+      for w = 0 to bytes_per_line - 1 do
+        let bitcount =
+          if ((w + 1) * 8) < gw then 8
+          else (gw - (w * 8)) mod 8
+        in
         let b = int_of_char (Bytes.get bmp ((h * bytes_per_line) + w)) in
-        for bit = 0 to (bitcount - 1) do
-          let isbit = (b lsl bit) land 0x80 in
-          match isbit with
-          | 0 -> ()
-          | _ ->
-          pixel_write
-            (x + (w * 8) + bit)
-            (y + h)
-            col
-            buffer
+        for bit = 0 to bitcount - 1 do
+          if ((b lsl bit) land 0x80) <> 0 then
+            pixel_write (x + (w * 8) + bit) (y + h) col buffer
         done
       done
-    done; gw
-  )
+    done;
+    gw
+
 
 let draw_string (x : int) (y : int) (f : Font.t) (s : string) (col : int) (buffer : t) =
-  buffer.dirty <- true;
-  let sl = List.init (String.length s) (String.get s) in
-  let rec loop offset remaining =
-    match remaining with
+  let chars = List.init (String.length s) (String.get s) in
+  let rec loop offset = function
     | [] -> offset
-    | c :: remaining -> (
-      let width = draw_char (x + offset) y f c col buffer in
-      loop (offset + width) remaining
-    )
-  in loop 0 sl
+    | c :: rest ->
+      let w = draw_char (x + offset) y f c col buffer in
+      loop (offset + w) rest
+  in
+  loop 0 chars
 
 (* ----- *)
 
-let map (f: shader_func) (buffer : t) : t =
+let map (f : shader_func) (buffer : t) : t =
   Array.map (fun row ->
     Array.map f row
-  ) buffer
+  ) buffer.data |> fun data -> { data; dirty = true }
 
-let mapi (f: shaderi_func) (buffer : t) : t =
-  Array.mapi (fun y row ->
-    Array.mapi (fun x _p -> f x y buffer) row
-  ) buffer
+let mapi (f : shaderi_func) (buffer : t) : t =
+  let height = Array.length buffer.data in
+  let width = if height = 0 then 0 else Array.length buffer.data.(0) in
+  let new_data = Array.init height (fun y ->
+    Array.init width (fun x -> f x y buffer)
+  ) in
+  { data = new_data; dirty = true }
 
-let map_inplace (f: shader_func) (buffer : t) =
-  Array.iter (fun row ->
-    Array.iteri (fun i v -> row.(i) <- f v) row
-    (* Array.map_inplace f row*)
-  ) buffer;
+let map_inplace (f : shader_func) (buffer : t) =
+  let height = Array.length buffer.data in
+  if height > 0 then
+    let width = Array.length buffer.data.(0) in
+    for y = 0 to height - 1 do
+      for x = 0 to width - 1 do
+        buffer.data.(y).(x) <- f buffer.data.(y).(x)
+      done
+    done;
   buffer.dirty <- true
 
-let mapi_inplace (f: shaderi_func) (buffer : t) =
-  Array.iteri (fun y row ->
-    Array.iteri (fun x _v -> row.(x) <- f x y buffer) row
-    (* Array.mapi_inplace (fun x _p -> f x y buffer) row*)
-  ) buffer;
+let mapi_inplace (f : shaderi_func) (buffer : t) =
+  let height = Array.length buffer.data in
+  if height > 0 then
+    let width = Array.length buffer.data.(0) in
+    for y = 0 to height - 1 do
+      for x = 0 to width - 1 do
+        buffer.data.(y).(x) <- f x y buffer
+      done
+    done;
   buffer.dirty <- true
 
 (* ---- *)
 
 let render (buffer : t) (draw : Primitives.t list) =
-  List.iter (fun prim ->
-    match prim with
-    | Primitives.Circle (point, r, col) -> draw_circle point.x point. y r col buffer
-    | Primitives.FilledCircle (point, r, col) -> filled_circle point.x point.y r col buffer
-    | Primitives.Line (p1, p2, col) -> draw_line p1.x p1.y p2.x p2.y col buffer
-    | Primitives.Pixel (p, col) -> pixel_write p.x p.y col buffer
-    | Primitives.Polygon (plist, col) -> draw_polygon (List.map (fun (p : Primitives.point) -> (p.x, p.y)) plist) col buffer
-    | Primitives.FilledPolygon (plist, col) -> filled_polygon (List.map (fun (p : Primitives.point) -> (p.x, p.y)) plist) col buffer
-    | Primitives.Rect (p1, p2, col) -> draw_rect p1.x p1.y (p2.x - p1.x) (p2.y - p1.y) col buffer
-    | Primitives.FilledRect (p1, p2, col) -> filled_rect p1.x p1.y (p2.x - p1.x) (p2.y - p1.y) col buffer
-    | Primitives.Triangle (p1, p2, p3, col) -> draw_triangle p1.x p1.y p2.x p2.y p3.x p3.y col buffer
-    | Primitives.FilledTriangle (p1, p2, p3, col) -> filled_triangle p1.x p1.y p2.x p2.y p3.x p3.y col buffer
-    | Primitives.Char (p, font, c, col) -> ignore (draw_char p.x p.y font c col buffer)
-    | Primitives.String (p, font, s, col) -> ignore (draw_string p.x p.y font s col buffer )
+  List.iter (function
+    | Primitives.Circle (point, r, col) ->
+        draw_circle point.x point.y r col buffer
+    | Primitives.FilledCircle (point, r, col) ->
+        filled_circle point.x point.y r col buffer
+    | Primitives.Line (p1, p2, col) ->
+        draw_line p1.x p1.y p2.x p2.y col buffer
+    | Primitives.Pixel (p, col) ->
+        pixel_write p.x p.y col buffer
+    | Primitives.Polygon (plist, col) ->
+        draw_polygon (List.map (fun (p : Primitives.point) -> (p.x, p.y)) plist) col buffer
+    | Primitives.FilledPolygon (plist, col) ->
+        filled_polygon (List.map (fun (p : Primitives.point) -> (p.x, p.y)) plist) col buffer
+    | Primitives.Rect (p1, p2, col) ->
+        draw_rect p1.x p1.y (p2.x - p1.x) (p2.y - p1.y) col buffer
+    | Primitives.FilledRect (p1, p2, col) ->
+        filled_rect p1.x p1.y (p2.x - p1.x) (p2.y - p1.y) col buffer
+    | Primitives.Triangle (p1, p2, p3, col) ->
+        draw_triangle p1.x p1.y p2.x p2.y p3.x p3.y col buffer
+    | Primitives.FilledTriangle (p1, p2, p3, col) ->
+        filled_triangle p1.x p1.y p2.x p2.y p3.x p3.y col buffer
+    | Primitives.Char (p, font, c, col) ->
+        ignore (draw_char p.x p.y font c col buffer)
+    | Primitives.String (p, font, s, col) ->
+        ignore (draw_string p.x p.y font s col buffer)
   ) draw
 
 (* ----- *)
 
 let map2 (f : int -> int -> int) (origin : t) (delta : t) : t =
+  let odata = origin.data and ddata = delta.data in
   try
-    Array.map2 (fun o_row d_row ->
-      Array.map2 (fun o_pixel d_pixel ->
-        f o_pixel d_pixel
-      ) o_row d_row
-    ) origin delta
+    let merged =
+      Array.map2 (fun o_row d_row ->
+        Array.map2 (fun o_pixel d_pixel -> f o_pixel d_pixel) o_row d_row
+      ) odata ddata
+    in
+    { data = merged; dirty = true }
   with
-  | Invalid_argument _ -> raise (Invalid_argument "Merging framebuffers requires both to have same dimensions")
+  | Invalid_argument _ ->
+    raise (Invalid_argument "Merging framebuffers requires both to have same dimensions")
 
 let map2_inplace (f : int -> int -> int) (origin : t) (delta : t) =
+  let odata = origin.data and ddata = delta.data in
   try
     Array.iter2 (fun o_row d_row ->
       Array.iteri (fun index d_pixel ->
         o_row.(index) <- f o_row.(index) d_pixel
       ) d_row
-    ) origin delta
+    ) odata ddata;
+    origin.dirty <- true
   with
-  | Invalid_argument _ -> raise (Invalid_argument "Merging framebuffers requires both to have same dimensions")
+  | Invalid_argument _ ->
+    raise (Invalid_argument "Merging framebuffers requires both to have same dimensions")
+
+let is_dirty (buffer : t) = buffer.dirty
+
+let set_dirty (buffer : t) =
+  buffer.dirty <- true
+
+let clear_dirty (buffer : t) =
+  buffer.dirty <- false

--- a/src/framebuffer.ml
+++ b/src/framebuffer.ml
@@ -10,24 +10,21 @@ let to_array (buffer : t) : int array array =
 let init (dimensions : int * int) (f : int -> int -> int) : t =
   let width, height = dimensions in
   if width <= 0 then raise (Invalid_argument "Invalid width");
-  if height <= 0 then raise (Invalid_argument "Invalid height");  
+  if height <= 0 then raise (Invalid_argument "Invalid height");
   { data = Array.init height (fun y ->
-      Array.init width (fun x ->
+    Array.init width (fun x ->
         f x y
       )
-    );
+  );
     dirty = true }
 
 let pixel_write (x : int) (y : int) (col : int) (buffer : t) =
-  if (x >= 0) && (x < Array.length (buffer.data.(0)))
-     && (y >= 0) && (y < Array.length buffer.data) then (
+  if (x >= 0) && (x < Array.length (buffer.data.(0))) && (y >= 0) && (y < Array.length buffer.data) then
     buffer.data.(y).(x) <- col;
-    buffer.dirty <- true
-  )
+  buffer.dirty <- true
 
 let pixel_read (x : int) (y : int) (buffer : t) : int option =
-  if (x >= 0) && (x < Array.length (buffer.data.(0)))
-     && (y >= 0) && (y < Array.length buffer.data) then
+  if (x >= 0) && (x < Array.length (buffer.data.(0))) && (y >= 0) && (y < Array.length buffer.data) then
     Some buffer.data.(y).(x)
   else
     None
@@ -35,6 +32,7 @@ let pixel_read (x : int) (y : int) (buffer : t) : int option =
 let draw_circle (x : int) (y : int) (r : float) (col : int) (buffer : t) =
   let fx = Float.of_int x
   and fy = Float.of_int y in
+
   for yo = 0 to (Int.of_float (r *. sin (Float.pi *. 0.25))) do
     let yi = y + yo in
     let a = acos ((Float.of_int (yi - y)) /. r) in
@@ -49,11 +47,11 @@ let draw_circle (x : int) (y : int) (r : float) (col : int) (buffer : t) =
     pixel_write (x - yo) (Int.of_float (fy -. xw)) col buffer;
     pixel_write (x + yo) (Int.of_float (fy +. xw)) col buffer;
     pixel_write (x - yo) (Int.of_float (fy +. xw)) col buffer;
+
   done
 
 let filled_circle (x : int) (y : int) (r : float) (col : int) (buffer : t) =
-  let fx = Float.of_int x
-  and fy = Float.of_int y in
+  let fx = Float.of_int x and fy = Float.of_int y in
   let my = Float.of_int ((Array.length buffer.data) - 1)
   and mx = Float.of_int ((Array.length buffer.data.(0)) - 1) in
   let pminy = fy -. r
@@ -61,15 +59,17 @@ let filled_circle (x : int) (y : int) (r : float) (col : int) (buffer : t) =
   let miny = if (pminy < 0.) then 0. else pminy
   and maxy = if (pmaxy > my) then my else pmaxy in
   for yi = (Int.of_float miny) to (Int.of_float maxy) do
+    let row = buffer.data.(yi) in
     let a = acos ((Float.of_int (yi - y)) /. r) in
     let xw = (sin a) *. r in
     let pminx = fx -. xw
     and pmaxx = fx +. xw in
     let minx = if (pminx < 0.) then 0. else pminx
     and maxx = if (pmaxx > mx) then mx else pmaxx in
-    for xi = (Int.of_float minx) to (Int.of_float maxx) do
-      pixel_write xi yi col buffer
-    done
+    if (maxx > 0.0) && (minx < mx) then
+      for xi = (Int.of_float minx) to (Int.of_float maxx) do
+        row.(xi) <- col
+      done
   done
 
 let draw_line (x0 : int) (y0 : int) (x1 : int) (y1 : int) (col : int) (buffer : t) =
@@ -78,46 +78,53 @@ let draw_line (x0 : int) (y0 : int) (x1 : int) (y1 : int) (col : int) (buffer : 
   and dy = (abs (y1 - y0)) * -1
   and sy = if y0 < y1 then 1 else -1 in
   let initial_error = dx + dy in
-  let rec loop (x : int) (y : int) (error : int) =
-    pixel_write x y col buffer;
-    if (x = x1) && (y = y1) then ()
-    else begin
-      let e2 = 2 * error in
-      let nx = if e2 >= dy then x + sx else x in
-      let ny = if e2 <= dx then y + sy else y in
-      let nex = if e2 >= dy then dy else 0 in
-      let ney = if e2 <= dx then dx else 0 in
-      loop nx ny (error + nex + ney)
-    end
-  in
-  loop x0 y0 initial_error
 
+  let rec loop (x : int) (y : int) (error : int) =
+    if (x >= 0) && (x < Array.length (buffer.data.(0))) && (y >= 0) && (y < Array.length buffer.data) then
+      buffer.data.(y).(x) <- col;
+    match (x == x1) && (y == y1) with
+    | true -> ()
+    | false -> (
+      let e2 = 2 * error in
+      let nx = match e2 >= dy with
+      | false -> x
+      | true -> x + sx in
+      let ny = match e2 <= dx with
+      | false -> y
+      | true -> y + sy in
+      let nex = match (e2 >= dy) with
+      | false -> 0
+      | true -> dy in
+      let ney = match (e2 <= dx) with
+      | false -> 0
+      | true -> dx in
+      loop nx ny (error + nex + ney)
+    )
+  in loop x0 y0 initial_error
 
 let draw_polygon (points : (int * int) list) (col : int) (buffer : t) =
   match points with
   | [] -> ()
-  | hd :: tl ->
+  | hd :: tl -> (
     let rec loop start prev rest =
       let x0, y0 = prev in
       match rest with
       | [] -> ()
-      | ihd :: [] ->
+      | ihd :: [] -> (
         let x1, y1 = ihd in
         draw_line x0 y0 x1 y1 col buffer;
         let xs, ys = start in
         draw_line x1 y1 xs ys col buffer;
-      | ihd :: itl ->
+      )
+      | ihd :: itl -> (
         let x1, y1 = ihd in
         draw_line x0 y0 x1 y1 col buffer;
         loop start ihd itl
-    in
-    loop hd hd tl
+      ) in loop hd hd tl
+  )
 
 let draw_rect (x : int) (y : int) (width : int) (height : int) (col : int) (buffer : t) =
-  draw_polygon [ (x, y);
-                 (x + width, y);
-                 (x + width, y + height);
-                 (x, y + height) ] col buffer
+  draw_polygon [ (x, y) ; (x + width, y) ; (x + width, y + height) ; (x , y + height)] col buffer
 
 let filled_rect (x : int) (y : int) (width : int) (height : int) (col : int) (buffer : t) =
   for oy = 0 to height do
@@ -130,8 +137,8 @@ let draw_triangle (x0 : int) (y0 : int) (x1 : int) (y1 : int) (x2 : int) (y2 : i
   draw_line x2 y2 x0 y0 col buffer
 
 type span =
-  | Only of int
-  | Pair of int * int
+| Only of int
+| Pair of int * int
 
 let interpolate_line (x0 : int) (y0 : int) (x1 : int) (y1 : int) : span array =
   let dx = abs (x1 - x0)
@@ -139,81 +146,92 @@ let interpolate_line (x0 : int) (y0 : int) (x1 : int) (y1 : int) : span array =
   and dy = (abs (y1 - y0)) * -1
   and sy = if y0 <= y1 then 1 else -1 in
   let initial_error = dx + dy in
-  let result : span option array = Array.init (abs (y1 - y0) + 1) (fun _ -> None) in
+
+  let result : span option array = Array.init (abs (y1 - y0) + 1) (fun _i -> None) in
   result.(0) <- Some (Only x0);
+
   let rec loop (x : int) (y : int) (error : int) =
-    if (x = x1) && (y = y1) then ()
-    else begin
+    match (x == x1) && (y == y1) with
+    | true -> ()
+    | false -> (
       let e2 = 2 * error in
-      let nx = if e2 >= dy then x + sx else x in
-      let ny = if e2 <= dx then y + sy else y in
-      let nex = if e2 >= dy then dy else 0 in
-      let ney = if e2 <= dx then dx else 0 in
+      let nx = match e2 >= dy with
+      | false -> x
+      | true -> x + sx in
+      let ny = match e2 <= dx with
+      | false -> y
+      | true -> y + sy in
+      let nex = match (e2 >= dy) with
+      | false -> 0
+      | true -> dy in
+      let ney = match (e2 <= dx) with
+      | false -> 0
+      | true -> dx in
       let index = ny - (y0 * sy) in
       result.(index) <- (
         match result.(index) with
         | None -> Some (Only nx)
-        | Some span ->
-          Some (
-            match span with
-            | Only a ->
-              if a = nx then Only a
-              else if a > nx then Pair (nx, a)
-              else Pair (a, nx)
-            | Pair (a, b) ->
-              if nx <= a then Pair (nx, b)
-              else Pair (a, nx)
-          )
+        | Some span -> Some (
+          match span with
+          | Only (a) -> (if a == nx then Only(a) else (if (a > nx) then Pair(nx, a) else (Pair(a, nx))))
+          | Pair (a, b) -> (if nx <= a then Pair(nx, b) else Pair(a, nx))
+        )
       );
       loop nx ny (error + nex + ney)
-    end
-  in
-  loop x0 y0 initial_error;
-  Array.map (function
+    )
+  in loop x0 y0 initial_error;
+  Array.map (fun maybe_span ->
+    match maybe_span with
     | None -> assert false
-    | Some span -> span
+    | Some (span) -> span
   ) result
 
 let leftmost span =
   match span with
-  | Only x -> x
+  | Only (x) -> x
   | Pair (x0, _) -> x0
 
 let rightmost span =
   match span with
-  | Only x -> x
+  | Only (x) -> x
   | Pair (_, x1) -> x1
 
 let filled_triangle (x0 : int) (y0 : int) (x1 : int) (y1 : int) (x2 : int) (y2 : int) (col : int) (buffer : t) =
-  let points = [(x0, y0); (x1, y1); (x2, y2)] in
-  let sorted_points = List.sort (fun (,ay) (,by) -> ay - by) points in
+  let points = [(x0, y0) ; (x1, y1) ; (x2, y2)] in
+  let sorted_points = List.sort (fun a b ->
+    let _, ay = a and _, by = b in
+    ay - by
+  ) points in
   let x0, y0 = List.nth sorted_points 0
   and x1, y1 = List.nth sorted_points 1
   and x2, y2 = List.nth sorted_points 2 in
+
   let long_edge = interpolate_line x0 y0 x2 y2 in
-  let other_edge =
-    if (y1 = y0) then
-      interpolate_line x1 y1 x2 y2
-    else if (y1 = y2) then
-      interpolate_line x0 y0 x1 y1
-    else
-      let s1 = interpolate_line x0 y0 x1 y1
-      and s2 = interpolate_line x1 y1 x2 y2 in
-      Array.concat [ s1; Array.sub s2 1 (Array.length s2 - 1) ]
-  in
-  assert (Array.length long_edge = Array.length other_edge);
+
+  let other_edge = if (y1 == y0) then (
+    interpolate_line x1 y1 x2 y2
+  ) else if (y1 == y2) then (
+    interpolate_line x0 y0 x1 y1
+  ) else (
+    let s1 = interpolate_line x0 y0 x1 y1
+    and s2 = interpolate_line x1 y1 x2 y2 in
+    Array.concat [s1 ; (Array.sub s2 1 ((Array.length s2) - 1))]
+  ) in
+  assert ((Array.length long_edge) == (Array.length other_edge));
+
   let spans = Array.map2 (fun a b -> (a, b)) long_edge other_edge in
-  Array.iteri (fun i (p, q) ->
+  Array.iteri (fun i s ->
     let index = y0 + i in
     if (index >= 0) && (index < Array.length buffer.data) then (
-      let p0, p1 = if leftmost p <= leftmost q then p, q else q, p in
+      let row = buffer.data.(y0 + i) in
+      let stride = Array.length row in
+      let p, q = s in
+      let p0, p1 = if (leftmost p <= leftmost q) then p, q else q, p in
       let r0, r1 = leftmost p0, rightmost p1 in
-      if (r1 >= 0) && (r0 < Array.length buffer.data.(index)) then (
-        let xstart = max 0 r0 in
-        let xend   = min (Array.length buffer.data.(index) - 1) r1 in
-        for x = xstart to xend do
-          pixel_write x index col buffer
-        done
+      if ((r1 > 0) && (r0 < (stride - 1))) then (
+        let x0 = if (r0 < 0) then 0 else (if (r0 >= stride) then (stride - 1) else r0)
+        and x1 = if (r1 < 0) then 0 else (if (r1 >= stride) then (stride - 1) else r1) in
+        Array.fill row x0 ((x1 - x0) + 1) col
       )
     )
   ) spans
@@ -221,12 +239,14 @@ let filled_triangle (x0 : int) (y0 : int) (x1 : int) (y1 : int) (x2 : int) (y2 :
 type strand = ((int * int) * (int * int)) list
 
 let strand_direction (s : strand) : int =
-  List.fold_right (fun (p0, p1) acc ->
+  List.fold_right (fun a acc ->
     match acc with
-    | 0 ->
-      let (, y0) = p0 and (, y1) = p1 in
+    | 0 -> (
+      let p0, p1 = a in
+      let _, y0 = p0 and _, y1 = p1 in
       let diff = y1 - y0 in
-      if diff = 0 then 0 else (diff / abs diff)
+      if (diff = 0) then 0 else (diff / abs(diff))
+    )
     | x -> x
   ) s 0
 
@@ -255,242 +275,249 @@ let points_to_lines points =
 let poly_to_strands (points : (int * int) list) : strand list =
   match points with
   | [] | [_] -> []
-  | points ->
+  (* | p1 :: p2 :: ptl -> ( *)
+  | points -> (
+
+    (* let rec point_list_to_lines p1 p2 pl acc =
+      match pl with
+      | [] -> (p1, p2) :: acc
+      | np :: tl -> point_list_to_lines p2 np tl ((p1, p2) :: acc)
+    in
+    let lines = point_list_to_lines p1 p2 ptl [] in *)
     let lines = Utils.points_to_lines points in
-    let rec loop last_direction current_strand result remaining =
+
+    let rec loop
+        (last_direction : int)
+        (current_strand : strand)
+        (result: strand list)
+        (remaining : ((int * int) * (int * int)) list)
+        : strand list =
       match remaining with
-      | [] ->
-        (match current_strand with
-         | [] -> result
-         | x -> x :: result)
-      | hd :: tl ->
+      | [] -> (match current_strand with
+        | [] -> result
+        | x -> (x :: result)
+      )
+      | hd :: tl -> (
         let p0, p1 = hd in
-        let (, y0) = p0 and (, y1) = p1 in
+        let _, y0 = p0 and _, y1 = p1 in
         let diff = y1 - y0 in
-        let direction = if diff = 0 then 0 else (diff / abs diff) in
-        if direction = 0 then
+        let direction = if (diff = 0) then 0 else (diff / abs(diff)) in
+        if direction == 0 then (
           loop last_direction (hd :: current_strand) result tl
-        else if direction = last_direction then
-          loop direction (hd :: current_strand) result tl
-        else
-          loop direction [hd] (current_strand :: result) tl
+        ) else (
+          if (direction == last_direction) then (
+            loop direction (hd :: current_strand) result tl
+          ) else (
+            loop direction [hd] (current_strand :: result) tl
+          )
+        )
+      )
     in
     let raw = loop 0 [] [] lines in
-    let unwrapped = List.filter (fun x -> List.length x > 0) raw in
-    if List.length unwrapped < 2 then unwrapped
-    else
+    let unwrapped = List.filter (fun x -> (List.length x) > 0) raw in
+    if (List.length unwrapped) < 2 then unwrapped else (
       let head_dir = strand_direction (List.hd unwrapped)
-      and end_dir  = strand_direction (List.hd (List.rev unwrapped)) in
-      if head_dir <> end_dir then unwrapped
-      else
+      and end_dir = strand_direction (List.hd (List.rev unwrapped)) in
+      if head_dir != end_dir then unwrapped else (
         let fore = List.hd unwrapped
         and shortened = List.tl unwrapped in
         let rev_shorted = List.rev shortened in
         let hd = List.hd rev_shorted in
         let rest = List.tl rev_shorted in
-        (List.concat [fore; hd]) :: rest
+        (List.concat [fore ; hd]) :: rest
+      )
+    )
+  )
 
 let interpolate_strand (strand : ((int * int) * (int * int)) list) : (int * span array) =
-  let spans = List.map (fun (p0, p1) ->
+  let spans = List.map (fun line ->
+    let p0, p1 = line in
     let x0, y0 = p0 and x1, y1 = p1 in
     if y0 <= y1 then
       (y0, interpolate_line x0 y0 x1 y1)
     else
       (y1, interpolate_line x1 y1 x0 y0)
   ) strand in
-  let sorted_spans = List.sort (fun (y0,) (y1,) -> y0 - y1) spans in
+  let sorted_spans = List.sort (fun a b ->
+    let y0, _ = a and y1, _ = b in y0 - y1
+  ) spans in
   match sorted_spans with
   | [] -> (0, [||])
-  | [y, arr] -> (y, arr)
-  | (y, first_span) :: tl ->
-    let rest = List.map (fun (_, sp) -> Array.sub sp 1 (Array.length sp - 1)) tl in
-    (y, Array.concat (first_span :: rest))
+  | hd :: [] -> hd
+  | hd :: tl -> (
+    let y0, first_span = hd in
+    let rest = List.map (fun x ->
+      let _, spans = x in
+      Array.sub spans 1 ((Array.length spans) - 1)
+    ) tl in
+    y0, Array.concat (first_span :: rest)
+  )
 
 let filled_polygon (points : (int * int) list) (col : int) (buffer : t) =
   match points with
   | [] | [_] -> ()
-  | _ ->
-    let sorted_points = List.sort (fun (,ay) (,by) -> ay - by) points in
-    let (_, min_y) = List.hd sorted_points
-    and (_, max_y) = List.hd (List.rev sorted_points) in
+  | _ -> (
+    let sorted_points = List.sort (fun a b ->
+      let _, ay = a and _, by = b in
+      ay - by
+    ) points in
+    let _, min_y = List.hd sorted_points
+    and _, max_y = List.hd (List.rev sorted_points) in
     let strands = poly_to_strands points in
     let rendered_strands = List.map interpolate_strand strands in
-    let map = Array.init ((max_y - min_y) + 1) (fun _ -> []) in
-    List.iter (fun (base_y, spans) ->
+
+    let map = Array.init ((max_y - min_y) + 1) (fun _i -> []) in
+    List.iter (fun l ->
+      let y, points = l in
       Array.iteri (fun i span ->
-        let index = (base_y + i) - min_y in
+        let index = (y + i) - min_y in
         map.(index) <- span :: map.(index)
-      ) spans
+      ) points
     ) rendered_strands;
-    let height = Array.length buffer.data in
-    Array.iteri (fun i row_spans ->
+
+    let height = Array.length buffer in
+    Array.iteri (fun i row ->
       let index = min_y + i in
-      if (index >= 0) && (index < height) then (
-        let row = buffer.data.(index) in
-        let stride = Array.length row in
-        let sorted_row = List.sort (fun a b -> (leftmost a) - (leftmost b)) row_spans in
+      if ((index >= 0) && (index < height)) then (
+
+        let brow = buffer.(index) in
+        let stride = Array.length brow in
+        let sorted_row = List.sort (fun a b -> (leftmost a) - (leftmost b)) row in
+
         let rec loop pairs =
           match pairs with
           | [] -> ()
-          | [one_span] ->
-            (match one_span with
-             | Only x ->
-               let x0 = max 0 (min (stride - 1) x) in
-               pixel_write x0 index col buffer
-             | Pair (raw_x0, raw_x1) ->
-               let x0 = max 0 (min (stride - 1) raw_x0)
-               and x1 = max 0 (min (stride - 1) raw_x1) in
-               for x = x0 to x1 do
-                 pixel_write x index col buffer
-               done)
-          | span_a :: span_b :: rest ->
-            let rx0 = leftmost span_a
-            and rx1 = rightmost span_b in
-            let clipped_x0 = max 0 (min (stride - 1) rx0)
-            and clipped_x1 = max 0 (min (stride - 1) rx1) in
-            for x = clipped_x0 to clipped_x1 do
-              pixel_write x index col buffer
-            done;
-            loop rest
-        in
-        loop sorted_row
+          | raw_x0 :: [] -> (
+            match raw_x0 with
+            | Only (x) -> (
+              let x0 = if (x < 0) then 0 else (if (x >= stride) then (stride - 1) else x) in
+              Array.fill brow x0 1 col;
+            )
+            | Pair (raw_x0, raw_x1) -> (
+              let x0 = if (raw_x0 < 0) then 0 else (if (raw_x0 >= stride) then (stride - 1) else raw_x0)
+              and x1 = if (raw_x1 < 0) then 0 else (if (raw_x1 >= stride) then (stride - 1) else raw_x1) in
+              let dist = (x1 - x0) + 1 in
+              Array.fill brow x0 dist col;
+            )
+          )
+          | raw_x0 :: raw_x1 :: tl -> (
+            let rx0 = leftmost raw_x0
+            and rx1 = rightmost raw_x1 in
+            if ((rx1 > 0) && (rx0 < (stride - 1))) then (
+              let x0 = if (rx0 < 0) then 0 else (if (rx0 >= stride) then (stride - 1) else rx0)
+              and x1 = if (rx1 < 0) then 0 else (if (rx1 >= stride) then (stride - 1) else rx1) in
+              let dist = (x1 - x0) + 1 in
+              Array.fill brow x0 dist col;
+            );
+            loop tl
+          )
+        in loop sorted_row
       )
     ) map
+  )
 
 (* ----- *)
 
 let draw_char (x : int) (y : int) (f : Font.t) (c : char) (col : int) (buffer : t) : int =
   match Font.glyph_of_char f (Uchar.of_char c) with
   | None -> 0
-  | Some glyph ->
+  | Some glyph -> (
     let gw, gh, _, _ = Font.Glyph.dimensions glyph in
     let bmp = Font.Glyph.bitmap glyph in
-    let bytes_per_line = Bytes.length bmp / gh in
-    for h = 0 to gh - 1 do
-      for w = 0 to bytes_per_line - 1 do
-        let bitcount =
-          if ((w + 1) * 8) < gw then 8
-          else (gw - (w * 8)) mod 8
-        in
+    let bytes_per_line = (Bytes.length bmp) / gh in
+    for h = 0 to (gh - 1) do
+      for w = 0 to (bytes_per_line - 1) do
+        let bitcount = if (((w + 1) * 8) < gw) then 8 else ((gw - (w * 8)) mod 8) in
         let b = int_of_char (Bytes.get bmp ((h * bytes_per_line) + w)) in
-        for bit = 0 to bitcount - 1 do
-          if ((b lsl bit) land 0x80) <> 0 then
-            pixel_write (x + (w * 8) + bit) (y + h) col buffer
+        for bit = 0 to (bitcount - 1) do
+          let isbit = (b lsl bit) land 0x80 in
+          match isbit with
+          | 0 -> ()
+          | _ ->
+          pixel_write
+            (x + (w * 8) + bit)
+            (y + h)
+            col
+            buffer
         done
       done
-    done;
-    gw
-
+    done; gw
+  )
 
 let draw_string (x : int) (y : int) (f : Font.t) (s : string) (col : int) (buffer : t) =
-  let chars = List.init (String.length s) (String.get s) in
-  let rec loop offset = function
+  let sl = List.init (String.length s) (String.get s) in
+  let rec loop offset remaining =
+    match remaining with
     | [] -> offset
-    | c :: rest ->
-      let w = draw_char (x + offset) y f c col buffer in
-      loop (offset + w) rest
-  in
-  loop 0 chars
+    | c :: remaining -> (
+      let width = draw_char (x + offset) y f c col buffer in
+      loop (offset + width) remaining
+    )
+  in loop 0 sl
 
 (* ----- *)
 
-let map (f : shader_func) (buffer : t) : t =
+let map (f: shader_func) (buffer : t) : t =
   Array.map (fun row ->
     Array.map f row
-  ) buffer.data |> fun data -> { data; dirty = true }
+  ) buffer
 
-let mapi (f : shaderi_func) (buffer : t) : t =
-  let height = Array.length buffer.data in
-  let width = if height = 0 then 0 else Array.length buffer.data.(0) in
-  let new_data = Array.init height (fun y ->
-    Array.init width (fun x -> f x y buffer)
-  ) in
-  { data = new_data; dirty = true }
+let mapi (f: shaderi_func) (buffer : t) : t =
+  Array.mapi (fun y row ->
+    Array.mapi (fun x _p -> f x y buffer) row
+  ) buffer
 
-let map_inplace (f : shader_func) (buffer : t) =
-  let height = Array.length buffer.data in
-  if height > 0 then
-    let width = Array.length buffer.data.(0) in
-    for y = 0 to height - 1 do
-      for x = 0 to width - 1 do
-        buffer.data.(y).(x) <- f buffer.data.(y).(x)
-      done
-    done;
+let map_inplace (f: shader_func) (buffer : t) =
+  Array.iter (fun row ->
+    Array.iteri (fun i v -> row.(i) <- f v) row
+    (* Array.map_inplace f row*)
+  ) buffer;
   buffer.dirty <- true
 
-let mapi_inplace (f : shaderi_func) (buffer : t) =
-  let height = Array.length buffer.data in
-  if height > 0 then
-    let width = Array.length buffer.data.(0) in
-    for y = 0 to height - 1 do
-      for x = 0 to width - 1 do
-        buffer.data.(y).(x) <- f x y buffer
-      done
-    done;
+let mapi_inplace (f: shaderi_func) (buffer : t) =
+  Array.iteri (fun y row ->
+    Array.iteri (fun x _v -> row.(x) <- f x y buffer) row
+    (* Array.mapi_inplace (fun x _p -> f x y buffer) row*)
+  ) buffer;
   buffer.dirty <- true
 
 (* ---- *)
 
 let render (buffer : t) (draw : Primitives.t list) =
-  List.iter (function
-    | Primitives.Circle (point, r, col) ->
-        draw_circle point.x point.y r col buffer
-    | Primitives.FilledCircle (point, r, col) ->
-        filled_circle point.x point.y r col buffer
-    | Primitives.Line (p1, p2, col) ->
-        draw_line p1.x p1.y p2.x p2.y col buffer
-    | Primitives.Pixel (p, col) ->
-        pixel_write p.x p.y col buffer
-    | Primitives.Polygon (plist, col) ->
-        draw_polygon (List.map (fun (p : Primitives.point) -> (p.x, p.y)) plist) col buffer
-    | Primitives.FilledPolygon (plist, col) ->
-        filled_polygon (List.map (fun (p : Primitives.point) -> (p.x, p.y)) plist) col buffer
-    | Primitives.Rect (p1, p2, col) ->
-        draw_rect p1.x p1.y (p2.x - p1.x) (p2.y - p1.y) col buffer
-    | Primitives.FilledRect (p1, p2, col) ->
-        filled_rect p1.x p1.y (p2.x - p1.x) (p2.y - p1.y) col buffer
-    | Primitives.Triangle (p1, p2, p3, col) ->
-        draw_triangle p1.x p1.y p2.x p2.y p3.x p3.y col buffer
-    | Primitives.FilledTriangle (p1, p2, p3, col) ->
-        filled_triangle p1.x p1.y p2.x p2.y p3.x p3.y col buffer
-    | Primitives.Char (p, font, c, col) ->
-        ignore (draw_char p.x p.y font c col buffer)
-    | Primitives.String (p, font, s, col) ->
-        ignore (draw_string p.x p.y font s col buffer)
+  List.iter (fun prim ->
+    match prim with
+    | Primitives.Circle (point, r, col) -> draw_circle point.x point. y r col buffer
+    | Primitives.FilledCircle (point, r, col) -> filled_circle point.x point.y r col buffer
+    | Primitives.Line (p1, p2, col) -> draw_line p1.x p1.y p2.x p2.y col buffer
+    | Primitives.Pixel (p, col) -> pixel_write p.x p.y col buffer
+    | Primitives.Polygon (plist, col) -> draw_polygon (List.map (fun (p : Primitives.point) -> (p.x, p.y)) plist) col buffer
+    | Primitives.FilledPolygon (plist, col) -> filled_polygon (List.map (fun (p : Primitives.point) -> (p.x, p.y)) plist) col buffer
+    | Primitives.Rect (p1, p2, col) -> draw_rect p1.x p1.y (p2.x - p1.x) (p2.y - p1.y) col buffer
+    | Primitives.FilledRect (p1, p2, col) -> filled_rect p1.x p1.y (p2.x - p1.x) (p2.y - p1.y) col buffer
+    | Primitives.Triangle (p1, p2, p3, col) -> draw_triangle p1.x p1.y p2.x p2.y p3.x p3.y col buffer
+    | Primitives.FilledTriangle (p1, p2, p3, col) -> filled_triangle p1.x p1.y p2.x p2.y p3.x p3.y col buffer
+    | Primitives.Char (p, font, c, col) -> ignore (draw_char p.x p.y font c col buffer)
+    | Primitives.String (p, font, s, col) -> ignore (draw_string p.x p.y font s col buffer )
   ) draw
 
 (* ----- *)
 
 let map2 (f : int -> int -> int) (origin : t) (delta : t) : t =
-  let odata = origin.data and ddata = delta.data in
   try
-    let merged =
-      Array.map2 (fun o_row d_row ->
-        Array.map2 (fun o_pixel d_pixel -> f o_pixel d_pixel) o_row d_row
-      ) odata ddata
-    in
-    { data = merged; dirty = true }
+    Array.map2 (fun o_row d_row ->
+      Array.map2 (fun o_pixel d_pixel ->
+        f o_pixel d_pixel
+      ) o_row d_row
+    ) origin delta
   with
-  | Invalid_argument _ ->
-    raise (Invalid_argument "Merging framebuffers requires both to have same dimensions")
+  | Invalid_argument _ -> raise (Invalid_argument "Merging framebuffers requires both to have same dimensions")
 
 let map2_inplace (f : int -> int -> int) (origin : t) (delta : t) =
-  let odata = origin.data and ddata = delta.data in
   try
     Array.iter2 (fun o_row d_row ->
       Array.iteri (fun index d_pixel ->
         o_row.(index) <- f o_row.(index) d_pixel
       ) d_row
-    ) odata ddata;
-    origin.dirty <- true
+    ) origin delta
   with
-  | Invalid_argument _ ->
-    raise (Invalid_argument "Merging framebuffers requires both to have same dimensions")
-
-let is_dirty (buffer : t) = buffer.dirty
-
-let set_dirty (buffer : t) =
-  buffer.dirty <- true
-
-let clear_dirty (buffer : t) =
-  buffer.dirty <- false
+  | Invalid_argument _ -> raise (Invalid_argument "Merging framebuffers requires both to have same dimensions")

--- a/src/framebuffer.ml
+++ b/src/framebuffer.ml
@@ -59,7 +59,6 @@ let filled_circle (x : int) (y : int) (r : float) (col : int) (buffer : t) =
   let miny = if (pminy < 0.) then 0. else pminy
   and maxy = if (pmaxy > my) then my else pmaxy in
   for yi = (Int.of_float miny) to (Int.of_float maxy) do
-    let row = buffer.data.(yi) in
     let a = acos ((Float.of_int (yi - y)) /. r) in
     let xw = (sin a) *. r in
     let pminx = fx -. xw
@@ -68,7 +67,7 @@ let filled_circle (x : int) (y : int) (r : float) (col : int) (buffer : t) =
     and maxx = if (pmaxx > mx) then mx else pmaxx in
     if (maxx > 0.0) && (minx < mx) then
       for xi = (Int.of_float minx) to (Int.of_float maxx) do
-        row.(xi) <- col
+        pixel_write xi yi col buffer
       done
   done
 
@@ -80,8 +79,7 @@ let draw_line (x0 : int) (y0 : int) (x1 : int) (y1 : int) (col : int) (buffer : 
   let initial_error = dx + dy in
 
   let rec loop (x : int) (y : int) (error : int) =
-    if (x >= 0) && (x < Array.length (buffer.data.(0))) && (y >= 0) && (y < Array.length buffer.data) then
-      buffer.data.(y).(x) <- col;
+    pixel_write x y col buffer;
     match (x == x1) && (y == y1) with
     | true -> ()
     | false -> (
@@ -223,7 +221,7 @@ let filled_triangle (x0 : int) (y0 : int) (x1 : int) (y1 : int) (x2 : int) (y2 :
   Array.iteri (fun i s ->
     let index = y0 + i in
     if (index >= 0) && (index < Array.length buffer.data) then (
-      let row = buffer.data.(y0 + i) in
+      let row = buffer.data.(index) in
       let stride = Array.length row in
       let p, q = s in
       let p0, p1 = if (leftmost p <= leftmost q) then p, q else q, p in
@@ -231,7 +229,9 @@ let filled_triangle (x0 : int) (y0 : int) (x1 : int) (y1 : int) (x2 : int) (y2 :
       if ((r1 > 0) && (r0 < (stride - 1))) then (
         let x0 = if (r0 < 0) then 0 else (if (r0 >= stride) then (stride - 1) else r0)
         and x1 = if (r1 < 0) then 0 else (if (r1 >= stride) then (stride - 1) else r1) in
-        Array.fill row x0 ((x1 - x0) + 1) col
+        for x = x0 to x1 do
+          pixel_write x index col buffer
+        done
       )
     )
   ) spans
@@ -375,12 +375,12 @@ let filled_polygon (points : (int * int) list) (col : int) (buffer : t) =
       ) points
     ) rendered_strands;
 
-    let height = Array.length buffer in
+    let height = Array.length buffer.data in
     Array.iteri (fun i row ->
       let index = min_y + i in
       if ((index >= 0) && (index < height)) then (
 
-        let brow = buffer.(index) in
+        let brow = buffer.data.(index) in
         let stride = Array.length brow in
         let sorted_row = List.sort (fun a b -> (leftmost a) - (leftmost b)) row in
 
@@ -397,7 +397,7 @@ let filled_polygon (points : (int * int) list) (col : int) (buffer : t) =
               let x0 = if (raw_x0 < 0) then 0 else (if (raw_x0 >= stride) then (stride - 1) else raw_x0)
               and x1 = if (raw_x1 < 0) then 0 else (if (raw_x1 >= stride) then (stride - 1) else raw_x1) in
               let dist = (x1 - x0) + 1 in
-              Array.fill brow x0 dist col;
+              if dist > 0 then Array.fill brow x0 dist col;
             )
           )
           | raw_x0 :: raw_x1 :: tl -> (
@@ -413,7 +413,8 @@ let filled_polygon (points : (int * int) list) (col : int) (buffer : t) =
           )
         in loop sorted_row
       )
-    ) map
+    ) map;
+    buffer.dirty <- true
   )
 
 (* ----- *)
@@ -458,27 +459,30 @@ let draw_string (x : int) (y : int) (f : Font.t) (s : string) (col : int) (buffe
 (* ----- *)
 
 let map (f: shader_func) (buffer : t) : t =
-  Array.map (fun row ->
-    Array.map f row
-  ) buffer
+  { data = Array.map (fun row ->
+      Array.map f row
+    ) buffer.data;
+    dirty = true }
+
 
 let mapi (f: shaderi_func) (buffer : t) : t =
-  Array.mapi (fun y row ->
-    Array.mapi (fun x _p -> f x y buffer) row
-  ) buffer
+  { data = Array.mapi (fun y row ->
+      Array.mapi (fun x _p -> f x y buffer) row
+    ) buffer.data;
+    dirty = true }
 
-let map_inplace (f: shader_func) (buffer : t) =
-  Array.iter (fun row ->
-    Array.iteri (fun i v -> row.(i) <- f v) row
-    (* Array.map_inplace f row*)
-  ) buffer;
-  buffer.dirty <- true
+    let map_inplace (f: shader_func) (buffer : t) =
+      Array.iter (fun row ->
+        Array.iteri (fun i v -> row.(i) <- f v) row
+      ) buffer.data;
+      buffer.dirty <- true
+    
 
 let mapi_inplace (f: shaderi_func) (buffer : t) =
   Array.iteri (fun y row ->
     Array.iteri (fun x _v -> row.(x) <- f x y buffer) row
     (* Array.mapi_inplace (fun x _p -> f x y buffer) row*)
-  ) buffer;
+  ) buffer.data;
   buffer.dirty <- true
 
 (* ---- *)
@@ -504,20 +508,34 @@ let render (buffer : t) (draw : Primitives.t list) =
 
 let map2 (f : int -> int -> int) (origin : t) (delta : t) : t =
   try
-    Array.map2 (fun o_row d_row ->
-      Array.map2 (fun o_pixel d_pixel ->
-        f o_pixel d_pixel
-      ) o_row d_row
-    ) origin delta
+    { data = Array.map2 (fun o_row d_row ->
+                Array.map2 (fun o_pixel d_pixel ->
+                  f o_pixel d_pixel
+                ) o_row d_row
+             ) origin.data delta.data;
+      dirty = true }
   with
   | Invalid_argument _ -> raise (Invalid_argument "Merging framebuffers requires both to have same dimensions")
 
-let map2_inplace (f : int -> int -> int) (origin : t) (delta : t) =
-  try
-    Array.iter2 (fun o_row d_row ->
-      Array.iteri (fun index d_pixel ->
-        o_row.(index) <- f o_row.(index) d_pixel
-      ) d_row
-    ) origin delta
-  with
-  | Invalid_argument _ -> raise (Invalid_argument "Merging framebuffers requires both to have same dimensions")
+  let map2_inplace (f : int -> int -> int) (origin : t) (delta : t) =
+    try
+      Array.iter2 (fun o_row d_row ->
+        Array.iteri (fun index d_pixel ->
+          o_row.(index) <- f o_row.(index) d_pixel
+        ) d_row
+      ) origin.data delta.data;
+      origin.dirty <- true
+    with
+    | Invalid_argument _ ->
+        raise (Invalid_argument "Merging framebuffers requires both to have same dimensions")
+  
+
+
+let is_dirty (buffer : t) : bool =
+  buffer.dirty
+
+let set_dirty (buffer : t) : unit =
+  buffer.dirty <- true
+
+let clear_dirty (buffer : t) : unit =
+  buffer.dirty <- false

--- a/src/framebuffer.mli
+++ b/src/framebuffer.mli
@@ -162,5 +162,10 @@ val to_array: t -> int array array
 (** {2 Dirty-bit support} *)
 
 val is_dirty: t -> bool
+(** [is_dirty framebuffer] returns [true] if the framebuffer has been marked as 'dirty'. *)
+
 val set_dirty: t -> unit
+(** [set_dirty framebuffer] marks the framebuffer as dirty. *)
+
 val clear_dirty: t -> unit
+(** [clear_dirty framebuffer] resets the dirty bit to false. *)

--- a/src/framebuffer.mli
+++ b/src/framebuffer.mli
@@ -1,9 +1,8 @@
-
 (** Provides the simulated framebuffer for Claudius.
 
 The framebuffer is logically an array of memory in which you draw using palette entries, similar to say how VGA worked on old PCs. *)
 
-type t
+type t = { data : int array array; mutable dirty : bool }
 
 (** {1 Initializations} *)
 
@@ -159,3 +158,9 @@ val pixel_read: int -> int -> t -> int option
 val to_array: t -> int array array
 (** [to_array framebuffer] converts the framebuffer into a 2D array. The top level array is an array
     of rows, and each row is an array of palette entry colours. *)
+
+(** {2 Dirty-bit support} *)
+
+val is_dirty: t -> bool
+val set_dirty: t -> unit
+val clear_dirty: t -> unit

--- a/test/test_primitives.ml
+++ b/test/test_primitives.ml
@@ -1,246 +1,309 @@
 open Claudius
 open OUnit2
 
+(* Helper: prepare a framebuffer by clearing its dirty bit and asserting it's clear *)
+let prepare_fb dims init_fun =
+  let fb = Framebuffer.init dims init_fun in
+  Framebuffer.clear_dirty fb;
+  assert_equal ~msg:"dirty bit should be false after clear" false (Framebuffer.is_dirty fb);
+  fb
+
 (* Line *)
 
 let test_draw_line_direct _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (line direct)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
   Framebuffer.draw_line 3 3 7 7 1 fb;
-  assert_equal ~msg:"after" (Some 1) (Framebuffer.pixel_read 5 5 fb)
+  assert_equal ~msg:"after (line direct)" (Some 1) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"dirty bit should be set after draw_line" true (Framebuffer.is_dirty fb)
+
 
 let test_draw_line_direct_off_framebuffer _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (line off)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
   Framebuffer.draw_line (-3) (-3) 7 7 1 fb;
-  assert_equal ~msg:"after" (Some 1) (Framebuffer.pixel_read 5 5 fb)
+  assert_equal ~msg:"after (line off)" (Some 1) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"dirty bit should be set after draw_line (off)" true (Framebuffer.is_dirty fb)
 
 let test_draw_line_with_primitive _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (line prim)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
   let line = Primitives.Line ({x = 3; y = 3}, {x = 7 ; y = 7}, 1) in
   Framebuffer.render fb [line];
-  assert_equal ~msg:"after" (Some 1) (Framebuffer.pixel_read 5 5 fb)
+  assert_equal ~msg:"after (line prim)" (Some 1) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"dirty bit should be set after render (line)" true (Framebuffer.is_dirty fb)
 
 (* Pixel *)
-
 let test_draw_pixel_with_primitive _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (pixel prim)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
   let prim = Primitives.Pixel ({x = 5; y = 5}, 1) in
   Framebuffer.render fb [prim];
-  assert_equal ~msg:"after" (Some 1) (Framebuffer.pixel_read 5 5 fb)
+  assert_equal ~msg:"after (pixel prim)" (Some 1) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"dirty bit should be set after render (pixel)" true (Framebuffer.is_dirty fb)
 
 (* Circle *)
-
 let test_draw_circle_direct _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (circle direct)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
   Framebuffer.draw_circle 5 5 2.0 1 fb;
-  assert_equal ~msg:"after center" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"after edge" (Some 1) (Framebuffer.pixel_read 5 7 fb)
+  assert_equal ~msg:"after center (circle direct)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"after edge (circle direct)" (Some 1) (Framebuffer.pixel_read 5 7 fb);
+  assert_equal ~msg:"dirty bit should be set after draw_circle" true (Framebuffer.is_dirty fb)
 
 let test_draw_circle_direct_off_framebuffer _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (circle off)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
   Framebuffer.draw_circle (-1) (-1) 3.0 1 fb;
-  assert_equal ~msg:"after" (Some 1) (Framebuffer.pixel_read 1 1 fb)
+  assert_equal ~msg:"after (circle off)" (Some 1) (Framebuffer.pixel_read 1 1 fb);
+  assert_equal ~msg:"dirty bit should be set after draw_circle (off)" true (Framebuffer.is_dirty fb)
 
 let test_draw_circle_with_primitive _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (circle prim)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
   let prim = Primitives.Circle ({x = 5; y = 5}, 2.0, 1) in
   Framebuffer.render fb [prim];
-  assert_equal ~msg:"after center" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"after edge" (Some 1) (Framebuffer.pixel_read 5 7 fb)
+  assert_equal ~msg:"after center (circle prim)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"after edge (circle prim)" (Some 1) (Framebuffer.pixel_read 5 7 fb);
+  assert_equal ~msg:"dirty bit should be set after render (circle)" true (Framebuffer.is_dirty fb)
 
 (* Filled circle *)
 
 let test_draw_filled_circle_direct _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (filled circle direct)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
   Framebuffer.filled_circle 5 5 2.0 1 fb;
-  assert_equal ~msg:"after center" (Some 1) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"after edge" (Some 1) (Framebuffer.pixel_read 5 7 fb)
+  assert_equal ~msg:"after center (filled circle direct)" (Some 1) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"after edge (filled circle direct)" (Some 1) (Framebuffer.pixel_read 5 7 fb);
+  assert_equal ~msg:"dirty bit should be set after filled_circle" true (Framebuffer.is_dirty fb)
 
 let test_draw_filled_circle_direct_off_framebuffer _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  Framebuffer.draw_circle (-1) (-1) 3.0 1 fb;
-  assert_equal ~msg:"after" (Some 1) (Framebuffer.pixel_read 1 1 fb)
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (filled circle off)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  Framebuffer.filled_circle (-1) (-1) 3.0 1 fb;
+  assert_equal ~msg:"after (filled circle off)" (Some 1) (Framebuffer.pixel_read 1 1 fb);
+  assert_equal ~msg:"dirty bit should be set after filled_circle (off)" true (Framebuffer.is_dirty fb)
 
 let test_draw_filled_circle_with_primitive _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (filled circle prim)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
   let prim = Primitives.FilledCircle ({x = 5; y = 5}, 2.0, 1) in
   Framebuffer.render fb [prim];
-  assert_equal ~msg:"after center" (Some 1) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"after edge" (Some 1) (Framebuffer.pixel_read 5 7 fb)
+  assert_equal ~msg:"after center (filled circle prim)" (Some 1) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"after edge (filled circle prim)" (Some 1) (Framebuffer.pixel_read 5 7 fb);
+  assert_equal ~msg:"dirty bit should be set after render (filled circle)" true (Framebuffer.is_dirty fb)
 
 (* Rect *)
 
 let test_draw_rect_direct _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 7 7 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (rect direct)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"before (rect direct)" (Some 0) (Framebuffer.pixel_read 7 7 fb);
   Framebuffer.draw_rect 3 3 3 3 1 fb;
-  assert_equal ~msg:"after center" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"after edge" (Some 1) (Framebuffer.pixel_read 6 6 fb)
+  assert_equal ~msg:"after center (rect direct)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"after edge (rect direct)" (Some 1) (Framebuffer.pixel_read 6 6 fb);
+  assert_equal ~msg:"dirty bit should be set after draw_rect" true (Framebuffer.is_dirty fb)
 
 let test_draw_rect_direct_off_framebuffer _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (rect off)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
   Framebuffer.draw_rect (-1) (-1) 3 3 1 fb;
-  assert_equal ~msg:"after" (Some 1) (Framebuffer.pixel_read 2 2 fb)
+  assert_equal ~msg:"after (rect off)" (Some 1) (Framebuffer.pixel_read 2 2 fb);
+  assert_equal ~msg:"dirty bit should be set after draw_rect (off)" true (Framebuffer.is_dirty fb)
 
 let test_draw_rect_with_primitive _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 7 7 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (rect prim)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"before (rect prim)" (Some 0) (Framebuffer.pixel_read 7 7 fb);
   let prim = Primitives.Rect ({x = 3; y = 3}, {x = 6; y = 6}, 1) in
   Framebuffer.render fb [prim];
-  assert_equal ~msg:"after center" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"after edge" (Some 1) (Framebuffer.pixel_read 6 6 fb)
+  assert_equal ~msg:"after center (rect prim)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"after edge (rect prim)" (Some 1) (Framebuffer.pixel_read 6 6 fb);
+  assert_equal ~msg:"dirty bit should be set after render (rect)" true (Framebuffer.is_dirty fb)
 
 (* Filled rect *)
 
 let test_draw_filled_rect_direct _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 7 7 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (filled rect direct)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"before (filled rect direct)" (Some 0) (Framebuffer.pixel_read 7 7 fb);
   Framebuffer.filled_rect 3 3 3 3 1 fb;
-  assert_equal ~msg:"after center" (Some 1) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"after edge" (Some 1) (Framebuffer.pixel_read 6 6 fb)
+  assert_equal ~msg:"after center (filled rect direct)" (Some 1) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"after edge (filled rect direct)" (Some 1) (Framebuffer.pixel_read 6 6 fb);
+  assert_equal ~msg:"dirty bit should be set after filled_rect" true (Framebuffer.is_dirty fb)
 
 let test_draw_filled_rect_direct_off_framebuffer _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (filled rect off)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
   Framebuffer.filled_rect (-1) (-1) 3 3 1 fb;
-  assert_equal ~msg:"after" (Some 1) (Framebuffer.pixel_read 2 2 fb)
+  assert_equal ~msg:"after (filled rect off)" (Some 1) (Framebuffer.pixel_read 2 2 fb);
+  assert_equal ~msg:"dirty bit should be set after filled_rect (off)" true (Framebuffer.is_dirty fb)
 
 let test_draw_filled_rect_with_primitive _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 7 7 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (filled rect prim)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"before (filled rect prim)" (Some 0) (Framebuffer.pixel_read 7 7 fb);
   let prim = Primitives.FilledRect ({x = 3; y = 3}, {x = 6; y = 6}, 1) in
   Framebuffer.render fb [prim];
-  assert_equal ~msg:"after center" (Some 1) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"after edge" (Some 1) (Framebuffer.pixel_read 6 6 fb)
+  assert_equal ~msg:"after center (filled rect prim)" (Some 1) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"after edge (filled rect prim)" (Some 1) (Framebuffer.pixel_read 6 6 fb);
+  assert_equal ~msg:"dirty bit should be set after render (filled rect)" true (Framebuffer.is_dirty fb)
 
 (* Triangle *)
 
 let test_draw_triangle_direct _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 7 7 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (triangle direct)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"before (triangle direct)" (Some 0) (Framebuffer.pixel_read 7 7 fb);
   Framebuffer.draw_triangle 3 3 5 8 8 3 1 fb;
-  assert_equal ~msg:"after center" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"after edge" (Some 1) (Framebuffer.pixel_read 5 3 fb)
+  assert_equal ~msg:"after (triangle direct)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"after (triangle direct)" (Some 1) (Framebuffer.pixel_read 5 3 fb);
+  assert_equal ~msg:"dirty bit should be set after draw_triangle" true (Framebuffer.is_dirty fb)
 
 let test_draw_triangle_direct_off_framebuffer _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (triangle off)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
   Framebuffer.draw_triangle (-1) (-1) 3 3 (-5) 3 1 fb;
-  assert_equal ~msg:"after" (Some 1) (Framebuffer.pixel_read 2 2 fb)
+  assert_equal ~msg:"after (triangle off)" (Some 1) (Framebuffer.pixel_read 2 2 fb);
+  assert_equal ~msg:"dirty bit should be set after draw_triangle (off)" true (Framebuffer.is_dirty fb)
 
 let test_draw_triangle_with_primitive _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 7 7 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (triangle prim)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"before (triangle prim)" (Some 0) (Framebuffer.pixel_read 7 7 fb);
   let prim = Primitives.Triangle ({x = 3; y = 3}, {x = 5; y = 8}, {x = 8; y = 3}, 1) in
   Framebuffer.render fb [prim];
-  assert_equal ~msg:"after center" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"after edge" (Some 1) (Framebuffer.pixel_read 5 3 fb)
+  assert_equal ~msg:"after (triangle prim)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"after (triangle prim)" (Some 1) (Framebuffer.pixel_read 5 3 fb);
+  assert_equal ~msg:"dirty bit should be set after render (triangle)" true (Framebuffer.is_dirty fb)
 
 (* Filled triangle *)
 
 let test_draw_filled_triangle_direct _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 7 7 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (filled triangle direct)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"before (filled triangle direct)" (Some 0) (Framebuffer.pixel_read 7 7 fb);
   Framebuffer.filled_triangle 3 3 5 8 8 3 1 fb;
-  assert_equal ~msg:"after center" (Some 1) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"after edge" (Some 1) (Framebuffer.pixel_read 5 3 fb)
+  assert_equal ~msg:"after (filled triangle direct)" (Some 1) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"after (filled triangle direct)" (Some 1) (Framebuffer.pixel_read 5 3 fb);
+  assert_equal ~msg:"dirty bit should be set after filled_triangle" true (Framebuffer.is_dirty fb)
 
 let test_draw_filled_triangle_direct_off_framebuffer _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (filled triangle off)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
   Framebuffer.filled_triangle (-1) (-1) 3 3 (-5) 3 1 fb;
-  assert_equal ~msg:"after" (Some 1) (Framebuffer.pixel_read 2 2 fb)
+  assert_equal ~msg:"after (filled triangle off)" (Some 1) (Framebuffer.pixel_read 2 2 fb);
+  assert_equal ~msg:"dirty bit should be set after filled_triangle (off)" true (Framebuffer.is_dirty fb)
 
 let test_draw_filled_triangle_with_primitive _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 7 7 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (filled triangle prim)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"before (filled triangle prim)" (Some 0) (Framebuffer.pixel_read 7 7 fb);
   let prim = Primitives.FilledTriangle ({x = 3; y = 3}, {x = 5; y = 8}, {x = 8; y = 3}, 1) in
   Framebuffer.render fb [prim];
-  assert_equal ~msg:"after center" (Some 1) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"after edge" (Some 1) (Framebuffer.pixel_read 5 3 fb)
+  assert_equal ~msg:"after (filled triangle prim)" (Some 1) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"after (filled triangle prim)" (Some 1) (Framebuffer.pixel_read 5 3 fb);
+  assert_equal ~msg:"dirty bit should be set after render (filled triangle)" true (Framebuffer.is_dirty fb)
 
 (* Polygon *)
-
 let test_draw_polygon_direct _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 7 7 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (polygon direct)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"before (polygon direct)" (Some 0) (Framebuffer.pixel_read 7 7 fb);
   Framebuffer.draw_polygon [(3, 3) ; (5, 8) ; (8, 3)] 1 fb;
-  assert_equal ~msg:"after center" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"after edge" (Some 1) (Framebuffer.pixel_read 5 3 fb)
+  assert_equal ~msg:"after (polygon direct)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"after (polygon direct)" (Some 1) (Framebuffer.pixel_read 5 3 fb);
+  assert_equal ~msg:"dirty bit should be set after draw_polygon" true (Framebuffer.is_dirty fb)
 
 let test_draw_polygon_direct_off_framebuffer _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (polygon off)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
   Framebuffer.draw_polygon [(-1, -1) ; (3, 3) ; (-5, 3)] 1 fb;
-  assert_equal ~msg:"after" (Some 1) (Framebuffer.pixel_read 2 2 fb)
+  assert_equal ~msg:"after (polygon off)" (Some 1) (Framebuffer.pixel_read 2 2 fb);
+  assert_equal ~msg:"dirty bit should be set after draw_polygon (off)" true (Framebuffer.is_dirty fb)
 
 let test_draw_polygon_with_primitive _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 7 7 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (polygon prim)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"before (polygon prim)" (Some 0) (Framebuffer.pixel_read 7 7 fb);
   let prim = Primitives.Polygon ([{x = 3; y = 3} ; {x = 5; y = 8} ; {x = 8; y = 3}], 1) in
   Framebuffer.render fb [prim];
-  assert_equal ~msg:"after center" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"after edge" (Some 1) (Framebuffer.pixel_read 5 3 fb)
+  assert_equal ~msg:"after (polygon prim)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"after (polygon prim)" (Some 1) (Framebuffer.pixel_read 5 3 fb);
+  assert_equal ~msg:"dirty bit should be set after render (polygon)" true (Framebuffer.is_dirty fb)
 
 (* Filled polygon *)
 
 let test_draw_filled_polygon_direct _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 7 7 fb);
-  Framebuffer.filled_polygon [(3, 3) ; (5, 8) ; (8, 3)] 1 fb;
-  assert_equal ~msg:"after center" (Some 1) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"after edge" (Some 1) (Framebuffer.pixel_read 5 3 fb)
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (filled polygon direct)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"before (filled polygon direct)" (Some 0) (Framebuffer.pixel_read 7 7 fb);
+  Framebuffer.filled_polygon [(3, 3); (5, 8); (8, 3)] 1 fb;
+  assert_equal ~msg:"after (filled polygon direct)" (Some 1) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"after (filled polygon direct)" (Some 1) (Framebuffer.pixel_read 5 3 fb);
+  assert_equal ~msg:"dirty bit should be set after filled_polygon" true (Framebuffer.is_dirty fb)
 
 let test_draw_filled_polygon_direct_off_framebuffer _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (filled polygon off)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
   Framebuffer.filled_polygon [(-1, -1) ; (3, 3) ; (-5, 3)] 1 fb;
-  assert_equal ~msg:"after" (Some 1) (Framebuffer.pixel_read 2 2 fb)
+  assert_equal ~msg:"after (filled polygon off)" (Some 1) (Framebuffer.pixel_read 2 2 fb);
+  assert_equal ~msg:"dirty bit should be set after filled_polygon (off)" true (Framebuffer.is_dirty fb)
 
 let test_draw_filled_polygon_with_primitive _ =
-  let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"before" (Some 0) (Framebuffer.pixel_read 7 7 fb);
+  let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
+  assert_equal ~msg:"before (filled polygon prim)" (Some 0) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"before (filled polygon prim)" (Some 0) (Framebuffer.pixel_read 7 7 fb);
   let prim = Primitives.FilledPolygon ([{x = 3; y = 3} ; {x = 5; y = 8} ; {x = 8; y = 3}], 1) in
   Framebuffer.render fb [prim];
-  assert_equal ~msg:"after center" (Some 1) (Framebuffer.pixel_read 5 5 fb);
-  assert_equal ~msg:"after edge" (Some 1) (Framebuffer.pixel_read 5 3 fb)
+  assert_equal ~msg:"after (filled polygon prim)" (Some 1) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"after (filled polygon prim)" (Some 1) (Framebuffer.pixel_read 5 3 fb);
+  assert_equal ~msg:"dirty bit should be set after render (filled polygon)" true (Framebuffer.is_dirty fb)
 
-  let test_dirty_bit_draw_line _ =
-    let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-    Framebuffer.clear_dirty fb;
-    assert_equal ~msg:"dirty bit should be false after clear" false (Framebuffer.is_dirty fb);
-    Framebuffer.draw_line 3 3 7 7 1 fb;
-    assert_equal ~msg:"dirty bit should be set after draw_line" true (Framebuffer.is_dirty fb)
-  
-  let test_dirty_bit_render_primitive _ =
-    let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
-    Framebuffer.clear_dirty fb;
-    assert_equal ~msg:"dirty bit should be false after clear" false (Framebuffer.is_dirty fb);
-    let prim = Primitives.Pixel ({x = 5; y = 5}, 1) in
+(* ----- Dirty Bit Test For All Primitives ----- *)
+let test_dirty_bit_render_primitive _ =
+  let primitives = [
+    Primitives.Pixel ({x = 5; y = 5}, 1);
+    Primitives.Line ({x = 2; y = 2}, {x = 5; y = 5}, 1);
+    Primitives.Circle ({x = 5; y = 5}, 4.0, 1);
+    Primitives.FilledCircle ({x = 5; y = 5}, 4.0, 1);
+    Primitives.Rect ({x = 3; y = 3}, {x = 6; y = 6}, 1);
+    Primitives.FilledRect ({x = 3; y = 3}, {x = 6; y = 6}, 1);
+    Primitives.Triangle ({x = 3; y = 3}, {x = 5; y = 8}, {x = 8; y = 3}, 1);
+    Primitives.FilledTriangle ({x = 3; y = 3}, {x = 5; y = 8}, {x = 8; y = 3}, 1);
+    Primitives.Polygon ([{x = 3; y = 3}; {x = 5; y = 8}; {x = 8; y = 3}], 1);
+    Primitives.FilledPolygon ([{x = 3; y = 3}; {x = 5; y = 8}; {x = 8; y = 3}], 1)
+  ] in
+  List.iter (fun prim ->
+    let fb = prepare_fb (10, 10) (fun _ _ -> 0) in
     Framebuffer.render fb [prim];
-    assert_equal ~msg:"dirty bit should be set after render" true (Framebuffer.is_dirty fb)
+    assert_equal ~msg:"dirty bit should be set after render (all prim)" true (Framebuffer.is_dirty fb)
+  ) primitives
+
+(* ----- Map Functions Tests ----- *)
+let test_map _ =
+  let fb = prepare_fb (10, 10) (fun _ _ -> 1) in
+  let fb2 = Framebuffer.map (fun x -> x + 1) fb in
+  assert_equal ~msg:"map should increase pixel value" (Some 2) (Framebuffer.pixel_read 5 5 fb2);
+  assert_equal ~msg:"dirty bit should be set in new framebuffer from map" true (Framebuffer.is_dirty fb2)
+
+let test_mapi _ =
+  let fb = prepare_fb (10, 10) (fun x y -> x + y) in
+  let fb2 = Framebuffer.mapi (fun x y _ -> x * y) fb in
+  assert_equal ~msg:"mapi should compute product" (Some 12) (Framebuffer.pixel_read 3 4 fb2);
+  assert_equal ~msg:"dirty bit should be set in new framebuffer from mapi" true (Framebuffer.is_dirty fb2)
+
+let test_map_inplace _ =
+  let fb = prepare_fb (10, 10) (fun _ _ -> 1) in
+  Framebuffer.map_inplace (fun x -> x * 2) fb;
+  assert_equal ~msg:"map_inplace should double pixel" (Some 2) (Framebuffer.pixel_read 5 5 fb);
+  assert_equal ~msg:"dirty bit should be set after map_inplace" true (Framebuffer.is_dirty fb)
+
+let test_mapi_inplace _ =
+  let fb = prepare_fb (10, 10) (fun x y -> x + y) in
+  Framebuffer.mapi_inplace (fun x y _ -> x * y) fb;
+  assert_equal ~msg:"mapi_inplace should compute product" (Some 12) (Framebuffer.pixel_read 3 4 fb);
+  assert_equal ~msg:"dirty bit should be set after mapi_inplace" true (Framebuffer.is_dirty fb)
 
 let suite =
   "Primitives tests" >::: [
@@ -272,8 +335,11 @@ let suite =
     "Test filled polygon direct" >:: test_draw_filled_polygon_direct ;
     "Test filled polygon direct off framebuffer" >:: test_draw_filled_polygon_direct_off_framebuffer ;
     "Test filled polygon with primative" >:: test_draw_filled_polygon_with_primitive ;
-    "Test dirty bit after draw_line" >:: test_dirty_bit_draw_line;
-    "Test dirty bit after render primitive" >:: test_dirty_bit_render_primitive;
+    "Test dirty bit render primitive (all prim)" >:: test_dirty_bit_render_primitive;
+    "Test map" >:: test_map ;
+    "Test mapi" >:: test_mapi ;
+    "Test map_inplace" >:: test_map_inplace ;
+    "Test mapi_inplace" >:: test_mapi_inplace ;
   ]
 
 let () =

--- a/test/test_primitives.ml
+++ b/test/test_primitives.ml
@@ -227,6 +227,21 @@ let test_draw_filled_polygon_with_primitive _ =
   assert_equal ~msg:"after center" (Some 1) (Framebuffer.pixel_read 5 5 fb);
   assert_equal ~msg:"after edge" (Some 1) (Framebuffer.pixel_read 5 3 fb)
 
+  let test_dirty_bit_draw_line _ =
+    let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
+    Framebuffer.clear_dirty fb;
+    assert_equal ~msg:"dirty bit should be false after clear" false (Framebuffer.is_dirty fb);
+    Framebuffer.draw_line 3 3 7 7 1 fb;
+    assert_equal ~msg:"dirty bit should be set after draw_line" true (Framebuffer.is_dirty fb)
+  
+  let test_dirty_bit_render_primitive _ =
+    let fb = Framebuffer.init (10, 10) (fun _ _ -> 0) in
+    Framebuffer.clear_dirty fb;
+    assert_equal ~msg:"dirty bit should be false after clear" false (Framebuffer.is_dirty fb);
+    let prim = Primitives.Pixel ({x = 5; y = 5}, 1) in
+    Framebuffer.render fb [prim];
+    assert_equal ~msg:"dirty bit should be set after render" true (Framebuffer.is_dirty fb)
+
 let suite =
   "Primitives tests" >::: [
     "Test draw line direct" >:: test_draw_line_direct ;
@@ -257,6 +272,8 @@ let suite =
     "Test filled polygon direct" >:: test_draw_filled_polygon_direct ;
     "Test filled polygon direct off framebuffer" >:: test_draw_filled_polygon_direct_off_framebuffer ;
     "Test filled polygon with primative" >:: test_draw_filled_polygon_with_primitive ;
+    "Test dirty bit after draw_line" >:: test_dirty_bit_draw_line;
+    "Test dirty bit after render primitive" >:: test_dirty_bit_render_primitive;
   ]
 
 let () =


### PR DESCRIPTION
I have reviewed the requested changes and recommendations from PR #33 and then deep-dived into the codebase once more.
I have changed my approach to this issue a slight, and am adding a new commit to the PR.

This PR fixes the issue #3 

I have done a minimal patch that lets the run loop detect if the newly returned framebuffer is physically the same as the old one (i.e. == in OCaml), and then skip repainting in that case. We still get the usual frame-delay logic (so it won’t spin too fast), but if we  return the same framebuffer from oour tick function, Claudius will skip doing the texture update/draw calls.

- After each tick, we are comparing updated_buffer with prev_buffer by physical equality (!= in OCaml).
- If they are not the same object, we do the usual framebuffer_to_bigarray + render_texture calls.
- If they are the same object, we skip the texture update/draw.
- We still do Sdl.delay diff at the start of each loop iteration, so the loop will not spin faster than our target frame rate (60fps in this snippet).
- Event polling continues exactly as before, so key presses etc. still work.

IMO this is a better approach to the issue. Is this approach correct or there are other things that are needed to be taken into consideration? Thanks :))
@mdales @patricoferris 