### PR TITLE
(WIP):Abstract fonts properly to allow more types to be used

### DIFF
--- a/claudius.opam
+++ b/claudius.opam
@@ -31,3 +31,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/mdales/claudius.git"
+pin-depends: [
+  ["bdfparser.dev" "git+https://github.com/claudiusFX/bdfparser.git#main"]
+]

--- a/claudius.opam.template
+++ b/claudius.opam.template
@@ -1,0 +1,3 @@
+pin-depends: [
+  ["bdfparser.dev" "git+https://github.com/claudiusFX/bdfparser.git#main"]
+]

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
  (name claudius)
  (public_name claudius)
- (libraries tsdl))
+ (libraries bdfparser tsdl))

--- a/src/fontv2.ml
+++ b/src/fontv2.ml
@@ -1,0 +1,47 @@
+open Bdfparser
+
+type t = 
+  | Psf of Psf.t
+  | Bdf of Bdf.t
+
+type glyph = 
+  | PsfGlyph of Psf.Glyph.t
+  | BdfGlyph of Bdf.Glyph.t
+
+let load_font (filename : string) : (t, string) result =
+  match Filename.extension filename with
+  | ".psf" -> 
+    (match Psf.load_psf_font filename with
+    | Ok psf -> Ok (Psf psf)
+    | Error e -> Error e)
+  | ".bdf" -> 
+    (match Bdf.create filename with
+    | Ok bdf -> Ok (Bdf bdf)
+    | Error e -> Error e)
+  | _ -> Error "Unknown font format"
+
+let glyph_of_char (font : t) (u : Uchar.t) : glyph option =
+  match font with
+  | Psf psf -> 
+    (match Psf.glyph_of_char psf u with
+    | Some g -> Some (PsfGlyph g)
+    | None -> None)
+  | Bdf bdf -> 
+    (match Bdf.glyph_of_char bdf u with
+    | Some g -> Some (BdfGlyph g)
+    | None -> None)
+
+let glyph_count (font : t) : int =
+  match font with
+  | Psf psf -> Psf.glyph_count psf
+  | Bdf bdf -> Bdf.glyph_count bdf
+
+let glyph_dimensions (glyph : glyph) : (int * int * int * int) =
+  match glyph with
+  | PsfGlyph g -> Psf.Glyph.dimensions g
+  | BdfGlyph b -> Bdf.Glyph.dimensions b
+
+let glyph_bitmap (glyph : glyph) : bytes =
+  match glyph with
+  | PsfGlyph g -> Psf.Glyph.bitmap g
+  | BdfGlyph b -> Bdf.Glyph.bitmap b

--- a/src/framebuffer.ml
+++ b/src/framebuffer.ml
@@ -418,12 +418,12 @@ let filled_polygon (points : (int * int) list) (col : int) (buffer : t) =
 
 (* ----- *)
 
-let draw_char (x : int) (y : int) (f : Font.t) (c : char) (col : int) (buffer : t) : int =
-  match Font.glyph_of_char f (Uchar.of_char c) with
+let draw_char (x : int) (y : int) (f : Fontv2.t) (c : char) (col : int) (buffer : t) : int =
+  match Fontv2.glyph_of_char f (Uchar.of_char c) with
   | None -> 0
   | Some glyph -> (
-    let gw, gh, _, _ = Font.Glyph.dimensions glyph in
-    let bmp = Font.Glyph.bitmap glyph in
+    let gw, gh, _, _ = Fontv2.glyph_dimensions glyph in
+    let bmp = Fontv2.glyph_bitmap glyph in
     let bytes_per_line = (Bytes.length bmp) / gh in
     for h = 0 to (gh - 1) do
       for w = 0 to (bytes_per_line - 1) do
@@ -444,7 +444,7 @@ let draw_char (x : int) (y : int) (f : Font.t) (c : char) (col : int) (buffer : 
     done; gw
   )
 
-let draw_string (x : int) (y : int) (f : Font.t) (s : string) (col : int) (buffer : t) =
+let draw_string (x : int) (y : int) (f : Fontv2.t) (s : string) (col : int) (buffer : t) =
   let sl = List.init (String.length s) (String.get s) in
   let rec loop offset remaining =
     match remaining with

--- a/src/framebuffer.mli
+++ b/src/framebuffer.mli
@@ -74,11 +74,11 @@ val filled_polygon: (int * int) list -> int -> t -> unit
 (** [filled_polygon points colour framebuffer] Draws a filled polygon made from the list of [points]
     in the specified [colour] into [framebuffer]. *)
 
-val draw_char: int -> int -> Font.t -> char -> int -> t -> int
+val draw_char: int -> int -> Fontv2.t -> char -> int -> t -> int
 (** [draw_char x y font c colour framebuffer] Draws a single character [c] in the specified [colour] using [font]. The top left of
     the charcter is the point specified by position ([x], [y]). The return value is the number of pixels wide the character was. *)
 
-val draw_string: int -> int -> Font.t -> string -> int -> t -> int
+val draw_string: int -> int -> Fontv2.t -> string -> int -> t -> int
 (** [draw_string x y font s colour framebuffer] Draws the string [s] in the specified [colour] using [font]. The top left of
     the first charcter is the point specified by position ([x], [y]). The return value is the number of pixels wide the string was. *)
 

--- a/src/primitives.ml
+++ b/src/primitives.ml
@@ -14,6 +14,6 @@ type t =
 | FilledRect of point * point * int
 | Triangle of point * point * point * int
 | FilledTriangle of point * point * point * int
-| Char of point * Font.t * char * int
-| String of point * Font.t * string * int
+| Char of point * Fontv2.t * char * int
+| String of point * Fontv2.t * string * int
 

--- a/src/primitives.mli
+++ b/src/primitives.mli
@@ -16,5 +16,5 @@ type t =
 | FilledRect of point * point * int
 | Triangle of point * point * point * int
 | FilledTriangle of point * point * point * int
-| Char of point * Font.t * char * int
-| String of point * Font.t * string * int
+| Char of point * Fontv2.t * char * int
+| String of point * Fontv2.t * string * int

--- a/src/psf.ml
+++ b/src/psf.ml
@@ -1,0 +1,162 @@
+(** Hello *)
+
+
+(* https://wiki.osdev.org/PC_Screen_Font *)
+
+type psfheader = {
+  magic : int32;
+  version : int32;
+  headersize : int32;
+  flags : int32;
+  number_of_glyphs : int32;
+  bytes_per_glyph : int32;
+  height : int32;
+  width : int32;
+}
+
+module Glyph = struct
+  type t = {
+    bitmap : bytes;
+    width : int;
+    height : int;
+  }
+
+  let dimensions g =
+    (g.width, g.height, 0, 0)
+
+  let bitmap g =
+    g.bitmap
+
+end
+
+type t = {
+  header : psfheader;
+  glyphs : bytes array;
+  map : (Uchar.t * int) list;
+}
+
+
+(* ----- internal ----- *)
+
+let read_header (ic : in_channel) : (psfheader, string) result =
+  let header_buffer = Bytes.create (4 * 8) in
+  try 
+    really_input ic header_buffer 0 (Bytes.length header_buffer);
+    Result.ok  {
+      magic = Bytes.get_int32_le header_buffer 0 ;
+      version = Bytes.get_int32_le header_buffer 4 ;
+      headersize = Bytes.get_int32_le header_buffer 8 ;
+      flags = Bytes.get_int32_le header_buffer 12 ;
+      number_of_glyphs = Bytes.get_int32_le header_buffer 16 ;
+      bytes_per_glyph = Bytes.get_int32_le header_buffer 20 ;
+      height = Bytes.get_int32_le header_buffer 24 ;
+      width = Bytes.get_int32_le header_buffer 28 ;
+    }
+  with 
+  | Sys_error(reason) -> Result.error reason
+
+let load_glyphs ic header : (bytes array, string) result =
+  let bpg = Int32.to_int header.bytes_per_glyph in
+  try
+    Result.ok (Array.init (Int32.to_int header.number_of_glyphs) (fun i -> 
+      let buffer = Bytes.create bpg in
+      In_channel.seek ic (Int64.of_int ((Int32.to_int header.headersize) + (i * bpg)));
+      really_input ic buffer 0 bpg;
+      buffer
+    ))
+  with 
+  | Sys_error(reason) -> Result.error reason
+
+let inner_load_map_table ic header : ((Uchar.t * int) list, string) result =
+  try
+    In_channel.seek ic (Int64.of_int ((Int32.to_int header.headersize) + ((Int32.to_int header.number_of_glyphs) * (Int32.to_int header.bytes_per_glyph))));
+    let rec outerloop (counter : int) (tail : (Uchar.t * int) list list) : (Uchar.t * int) list list =
+      
+      let rec find_next_terminator (sofar : char list) : char list option =
+        try
+          match In_channel.input_char ic with
+          | None -> None
+          | Some (c) -> (match c with 
+            | '\255' -> Some sofar
+            | _ -> find_next_terminator (c :: sofar)
+          )
+        with
+        | Sys_error(_) -> None
+      in 
+      match (find_next_terminator []) with
+      | None -> tail
+      | Some bytes_list -> (
+        let next_batch_list = List.rev bytes_list in
+        let next_batch_buffer = Bytes.create (List.length next_batch_list) in
+        List.iteri (fun i c -> Bytes.set next_batch_buffer i c) next_batch_list;
+
+        let rec bytes_to_unicodes (offset : int) (tail : Uchar.t list) :  Uchar.t list = 
+          let remaining = (Bytes.length next_batch_buffer) - offset in
+          match remaining with
+          | 0 -> tail
+          | _ -> (
+            let c = Bytes.get_utf_8_uchar next_batch_buffer offset in
+            let size = Uchar.utf_decode_length c in
+            match Uchar.utf_decode_is_valid c with
+            | false -> bytes_to_unicodes (offset + size) tail
+            | true -> (
+              bytes_to_unicodes (offset + size) ((Uchar.utf_decode_uchar c) :: tail)
+            )
+          )
+        in
+        let char_list = bytes_to_unicodes 0 [] in
+        let this_uchars = List.map (fun c -> (c, counter)) char_list in
+        outerloop (counter + 1) (this_uchars :: tail)
+      )
+    in 
+    let rest = outerloop 0 [] in
+    Result.ok (List.concat rest)
+  with 
+  | Sys_error(reason) -> Result.error reason
+
+let load_map_table ic header : ((Uchar.t * int) list , string) result =
+  let flags = Int32.to_int header.flags in
+  match flags with
+  | 0 -> Result.ok (List.init (Int32.to_int header.number_of_glyphs) (fun i -> ((Uchar.of_int i), i)))
+  | 1 -> inner_load_map_table ic header
+  | _ -> Result.error (Printf.sprintf "Unrecognised header flag 0x%x" flags)
+
+
+let (>>=) = Result.bind
+
+(* ----- public ----- *)
+
+let load_psf_font (filename : string) : (t, string) result =
+  In_channel.with_open_bin filename (fun ic ->
+    read_header ic >>= fun header ->
+    load_glyphs ic header >>= fun glyphs ->
+    load_map_table ic header >>= fun map -> 
+    Result.ok {header ; glyphs ; map}
+  )
+
+let print_header (font : t) =
+  let header = font.header in 
+  Printf.printf "Magic:            0x%08x\n" ((Int32.to_int header.magic) land 0xFFFFFFFF);
+  Printf.printf "Version:          %d\n" (Int32.to_int header.version);
+  Printf.printf "Header Size:      %d\n" (Int32.to_int header.headersize);
+  Printf.printf "Flags:            0x%08x\n" ((Int32.to_int header.flags) land 0xFFFFFFFF);
+  Printf.printf "Number of Glyphs: %d\n" (Int32.to_int header.number_of_glyphs);
+  Printf.printf "Bytes per Glyph:  %d\n" (Int32.to_int header.bytes_per_glyph);
+  Printf.printf "Width:            %d\n" (Int32.to_int header.width);
+  Printf.printf "Height:           %d\n" (Int32.to_int header.height)
+
+let glyph_count (font : t) : int =
+  Int32.to_int font.header.number_of_glyphs
+
+let glyph_of_char (font : t) (u : Uchar.t) : Glyph.t option =
+  match (List.assoc_opt u font.map) with
+  | None -> None
+  | Some index -> (
+    match ((index >= 0) && (index < Array.length font.glyphs)) with
+    | false -> None
+    | true -> Some {
+      bitmap = font.glyphs.(index);
+      width = Int32.to_int font.header.width;
+      height = Int32.to_int font.header.height;
+    }
+  )

--- a/src/screen.ml
+++ b/src/screen.ml
@@ -4,7 +4,7 @@ type t = {
   height          : int ;
   scale           : int ;
   palette         : Palette.t ;
-  font            : Font.t option;
+  font            : Fontv2.t option;
 }
 
 
@@ -14,7 +14,7 @@ let create (width : int) (height : int) (scale : int) (palette : Palette.t) : t 
   if height <= 0 then raise (Invalid_argument "Invalid height");
   { width ; height ; scale ; palette ; font = None}
 
-let create_with_font (width : int) (height : int) (scale : int) (font : Font.t) (palette : Palette.t) : t =
+let create_with_font (width : int) (height : int) (scale : int) (font : Fontv2.t) (palette : Palette.t) : t =
   if scale <= 0 then raise (Invalid_argument "Invalid scale");
   if width <= 0 then raise (Invalid_argument "Invalid width");
   if height <= 0 then raise (Invalid_argument "Invalid height");
@@ -26,7 +26,7 @@ let dimensions (screen : t) : int * int =
 let palette (screen : t) : Palette.t =
   screen.palette
 
-let font (screen : t) : Font.t option =
+let font (screen : t) : Fontv2.t option =
   screen.font
 
 let scale (screen : t) : int =

--- a/src/screen.mli
+++ b/src/screen.mli
@@ -11,7 +11,7 @@ val create: int -> int -> int -> Palette.t -> t
     used when running will be indexed into the [palette] provided here. Raises [Invalid_argument] if
    the dimensions or scale are either zero or negative. *)
 
-val create_with_font: int -> int -> int -> Font.t -> Palette.t -> t
+val create_with_font: int -> int -> int -> Fontv2.t -> Palette.t -> t
 (** [create width height scale font palette] Creates a new screen of the specified size [width] x [height],
     and it will be rendered in a window scaled up by the [scale] factor provided. A font to be
     used for future rendering of characters is provided here. The framebuffers  used when running
@@ -29,5 +29,5 @@ val palette: t -> Palette.t
 val scale : t -> int
 (** [scale screen] Returns the scaling factor used when drawing [screen] to a window. *)
 
-val font : t -> Font.t option
+val font : t -> Fontv2.t option
 (** [font screen] Returns the font associated with the [screen] if one was provided, or [None] otherwise. *)


### PR DESCRIPTION
@mdales Here's my first pass at solving #2. I’ve introduced a new font layer (fontv2—will rename later) to encapsulate the public functions used in the framebuffer. This layer dynamically selects the appropriate parser/methods based on the font type.

Additionally, I’ve added bdfparser as a pinned dependency instead of vendoring its source code, as I believe this approach is cleaner. Let me know if you agree or have any concerns.

Please let me know if I’m heading in the right direction!