### PR TITLE
[Feature] Palette Management

### DIFF
--- a/src/base.ml
+++ b/src/base.ml
@@ -19,7 +19,6 @@ type tick_func = int -> Screen.t -> Framebuffer.t -> input_state -> Framebuffer.
 
 type bitmap_t = (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Array1.t
 
-
 (* ----- *)
 
 let (>>=) = Result.bind
@@ -52,7 +51,7 @@ let render_texture (r : Sdl.renderer) (texture : Sdl.texture) (s : Screen.t) (bi
 (* ----- *)
 
 let run (title : string) (boot : boot_func option) (tick : tick_func) (s : Screen.t) =
-  let make_full = Array.to_list Sys.argv |> List.exists (fun a -> (String.compare a "-f") == 0) in
+  let make_full = Array.to_list Sys.argv |> List.exists (fun a -> (String.compare a "-f") = 0) in
 
   let s = match make_full with
   | false -> s
@@ -72,7 +71,7 @@ let run (title : string) (boot : boot_func option) (tick : tick_func) (s : Scree
     | Error (`Msg e) -> Sdl.log "texture error: %s" e; exit 1
     | Ok texture ->
       (* This is a conversion layer, but allocaing bigarrays frequently is frowned upon
-         so we allocate it once here and re-use it. *)
+        so we allocate it once here and re-use it. *)
       let bitmap = (Bigarray.Array1.create Bigarray.int32 Bigarray.c_layout (width * height)) in
 
       let initial_buffer = match boot with
@@ -91,12 +90,13 @@ let run (title : string) (boot : boot_func option) (tick : tick_func) (s : Scree
         let updated_buffer = tick t s prev_buffer input in
         let input = { input with mouse = Mouse.clear_events input.mouse } in
 
-        if (updated_buffer != prev_buffer) || (Framebuffer.is_dirty updated_buffer) then (
+        if (updated_buffer != prev_buffer) || (Framebuffer.is_dirty updated_buffer) || (Screen.is_dirty s) then (
           framebuffer_to_bigarray s updated_buffer bitmap;
           (match render_texture r texture s bitmap with
            | Error (`Msg e) -> Sdl.log "Boot error: %s" e
            | Ok () -> ());
-          Framebuffer.clear_dirty updated_buffer
+          Framebuffer.clear_dirty updated_buffer;
+          Screen.clear_dirty s
         );
 
         match render_texture r texture s bitmap with

--- a/src/base.ml
+++ b/src/base.ml
@@ -51,7 +51,7 @@ let render_texture (r : Sdl.renderer) (texture : Sdl.texture) (s : Screen.t) (bi
 (* ----- *)
 
 let run (title : string) (boot : boot_func option) (tick : tick_func) (s : Screen.t) =
-  let make_full = Array.to_list Sys.argv |> List.exists (fun a -> (String.compare a "-f") = 0) in
+  let make_full = Array.to_list Sys.argv |> List.exists (fun a -> (String.compare a "-f") == 0) in
 
   let s = match make_full with
   | false -> s

--- a/src/palette.ml
+++ b/src/palette.ml
@@ -150,7 +150,7 @@ let circle_palette (pal : t) (offset : int) : t =
     pal.(new_index)
   )
 
-let updated_entry (pal : t) (index : int) (new_colors : new_index) : t =
+let updated_entry (pal : t) (index : int) (new_colors : int32) : t =
   let new_pal = Array.copy pal in
   if index < 0 || index >= Array.length new_pal then
     raise [Invalid_argument "This palette is longer than expected or invalid Palette Index"]

--- a/src/palette.ml
+++ b/src/palette.ml
@@ -143,14 +143,14 @@ let to_list (palette : t) : int list =
 =======
     List.map Int32.to_int (Array.to_list palette)
 
-let circle_palette (pal : t) (offset : int) : int32 =
+let circle_palette (pal : t) (offset : int) : t =
   let size = Array.length pal in
   Array.init size (fun index ->
     let new_index = (index + offset) mod size in
     pal.(new_index)
   )
 
-let updated_entry (pal : t) (index : init) (new_colors : new_index) : int32 =
+let updated_entry (pal : t) (index : init) (new_colors : new_index) : t =
   let new_pal = Array.copy pal in
   if index < 0 || index >= Array.length new_pal then
     raise [Invalid_argument "This palette is longer than expected or invalid Palette Index"]

--- a/src/palette.ml
+++ b/src/palette.ml
@@ -153,7 +153,7 @@ let circle_palette (pal : t) (offset : int) : t =
 let updated_entry (pal : t) (index : int) (new_colors : int32) : t =
   let new_pal = Array.copy pal in
   if index < 0 || index >= Array.length new_pal then
-    raise [Invalid_argument "This palette is longer than expected or invalid Palette Index"]
+    raise (Invalid_argument "This palette is longer than expected or invalid Palette Index")
   else
     new_pal.(index) <- new_colors;
   new_pal

--- a/src/palette.ml
+++ b/src/palette.ml
@@ -138,4 +138,23 @@ let index_to_rgb (palette : t) (index : int) : int32 =
   palette.(if index >= 0 then index else index + palsize)
 
 let to_list (palette : t) : int list =
+<<<<<<< HEAD
     List.map Int32.to_int (Array.to_list palette)
+=======
+    List.map Int32.to_int (Array.to_list palette)
+
+let circle_palette (pal : t) (offset : int) : int32 =
+  let size = Array.length pal in
+  Array.init size (fun index ->
+    let new_index = (index + offset) mod size in
+    pal.(new_index)
+  )
+
+let updated_entry (pal : t) (index : init) (new_colors : new_index) : int32 =
+  let new_pal = Array.copy pal in
+  if index < 0 || index >= Array.length new_pal then
+    raise [Invalid_argument "This palette is longer than expected or invalid Palette Index"]
+  else
+    new_pal.(index) <- new_colors;
+  new_pal
+>>>>>>> 0dabb1a (feat(screen, palette): enable dynamic palette updates for retro effects)

--- a/src/palette.ml
+++ b/src/palette.ml
@@ -150,7 +150,7 @@ let circle_palette (pal : t) (offset : int) : t =
     pal.(new_index)
   )
 
-let updated_entry (pal : t) (index : init) (new_colors : new_index) : t =
+let updated_entry (pal : t) (index : int) (new_colors : new_index) : t =
   let new_pal = Array.copy pal in
   if index < 0 || index >= Array.length new_pal then
     raise [Invalid_argument "This palette is longer than expected or invalid Palette Index"]

--- a/src/palette.ml
+++ b/src/palette.ml
@@ -138,23 +138,19 @@ let index_to_rgb (palette : t) (index : int) : int32 =
   palette.(if index >= 0 then index else index + palsize)
 
 let to_list (palette : t) : int list =
-<<<<<<< HEAD
-    List.map Int32.to_int (Array.to_list palette)
-=======
     List.map Int32.to_int (Array.to_list palette)
 
-let circle_palette (pal : t) (offset : int) : t =
+let circle_palette (pal : t) (offset : int) : int32 =
   let size = Array.length pal in
   Array.init size (fun index ->
     let new_index = (index + offset) mod size in
     pal.(new_index)
   )
 
-let updated_entry (pal : t) (index : int) (new_colors : int32) : t =
+let updated_entry (pal : t) (index : init) (new_colors : new_index) : int32 =
   let new_pal = Array.copy pal in
   if index < 0 || index >= Array.length new_pal then
-    raise (Invalid_argument "This palette is longer than expected or invalid Palette Index")
+    raise [Invalid_argument "This palette is longer than expected or invalid Palette Index"]
   else
     new_pal.(index) <- new_colors;
   new_pal
->>>>>>> 0dabb1a (feat(screen, palette): enable dynamic palette updates for retro effects)

--- a/src/palette.ml
+++ b/src/palette.ml
@@ -140,17 +140,21 @@ let index_to_rgb (palette : t) (index : int) : int32 =
 let to_list (palette : t) : int list =
     List.map Int32.to_int (Array.to_list palette)
 
-let circle_palette (pal : t) (offset : int) : int32 =
+let circle_palette (pal : t) (offset : int) : t =
   let size = Array.length pal in
   Array.init size (fun index ->
-    let new_index = (index + offset) mod size in
+    (* Calculate new index ensuring it is positive *)
+    let raw = index + offset in
+    let new_index = if raw < 0 then (raw mod size) + size else raw mod size in
     pal.(new_index)
   )
 
-let updated_entry (pal : t) (index : init) (new_colors : new_index) : int32 =
-  let new_pal = Array.copy pal in
-  if index < 0 || index >= Array.length new_pal then
-    raise [Invalid_argument "This palette is longer than expected or invalid Palette Index"]
+let updated_entry (pal : t) (index : int) (new_color : int * int * int) : t =
+  if index < 0 || index >= Array.length pal then
+    raise (Invalid_argument "Invalid palette index")
   else
-    new_pal.(index) <- new_colors;
-  new_pal
+    let (r, g, b) = new_color in
+    let new_int = Int32.of_int ((r * 65536) lor (g * 256) lor b) in
+    let new_pal = Array.copy pal in
+    new_pal.(index) <- new_int;
+    new_pal

--- a/src/palette.mli
+++ b/src/palette.mli
@@ -70,5 +70,5 @@ val index_to_rgb: t -> int -> int32
 val circle_palette: t -> int -> int32
 (**[circle_palette pal offset] returns a new palette with entries rotated to offset*)
 
-val update_entry: t -> int -> int32
-(** [update_entry pal index new_color] checks for the index then returns a new palette with the entry at [index] updated to [new_color]. *)
+val updated_entry : t -> int -> int32 -> t
+(** [updated_entry pal index new_color] checks for the index then returns a new palette with the entry at [index] updated to [new_color]. *)

--- a/src/palette.mli
+++ b/src/palette.mli
@@ -67,7 +67,7 @@ val size: t -> int
 val index_to_rgb: t -> int -> int32
 (** [index_to_rgb palette index] Will return the 24bpp RGB prepesentation of a [palette] entry at position [index]. As per other fantasy console systems, the index value will be wrapped if it is above or below the palette size. *)
 
-val circle_palette: t -> int -> int32
+val circle_palette: t -> int -> t
 (**[circle_palette pal offset] returns a new palette with entries rotated to offset*)
 
 val updated_entry : t -> int -> int32 -> t

--- a/src/palette.mli
+++ b/src/palette.mli
@@ -65,4 +65,14 @@ val size: t -> int
 (** [size palette] Returns the number of entries in the palette. *)
 
 val index_to_rgb: t -> int -> int32
+<<<<<<< HEAD
 (** [index_to_rgb palette index] Will return the 24bpp RGB prepesentation of a [palette] entry at position [index]. As per other fantasy console systems, the index value will be wrapped if it is above or below the palette size. *)
+=======
+(** [index_to_rgb palette index] Will return the 24bpp RGB prepesentation of a [palette] entry at position [index]. As per other fantasy console systems, the index value will be wrapped if it is above or below the palette size. *)
+
+val circle_palette: t -> int -> int32
+(**[circle_palette pal offset] returns a new palette with entries rotated to offset*)
+
+val update_entry: t -> int -> int32
+(** [update_entry pal index new_color] checks for the index then returns a new palette with the entry at [index] updated to [new_color]. *)
+>>>>>>> 0dabb1a (feat(screen, palette): enable dynamic palette updates for retro effects)

--- a/src/palette.mli
+++ b/src/palette.mli
@@ -65,14 +65,10 @@ val size: t -> int
 (** [size palette] Returns the number of entries in the palette. *)
 
 val index_to_rgb: t -> int -> int32
-<<<<<<< HEAD
-(** [index_to_rgb palette index] Will return the 24bpp RGB prepesentation of a [palette] entry at position [index]. As per other fantasy console systems, the index value will be wrapped if it is above or below the palette size. *)
-=======
 (** [index_to_rgb palette index] Will return the 24bpp RGB prepesentation of a [palette] entry at position [index]. As per other fantasy console systems, the index value will be wrapped if it is above or below the palette size. *)
 
-val circle_palette: t -> int -> t
+val circle_palette: t -> int -> int32
 (**[circle_palette pal offset] returns a new palette with entries rotated to offset*)
 
-val update_entry: t -> int -> t
+val update_entry: t -> int -> int32
 (** [update_entry pal index new_color] checks for the index then returns a new palette with the entry at [index] updated to [new_color]. *)
->>>>>>> 0dabb1a (feat(screen, palette): enable dynamic palette updates for retro effects)

--- a/src/palette.mli
+++ b/src/palette.mli
@@ -70,9 +70,9 @@ val index_to_rgb: t -> int -> int32
 =======
 (** [index_to_rgb palette index] Will return the 24bpp RGB prepesentation of a [palette] entry at position [index]. As per other fantasy console systems, the index value will be wrapped if it is above or below the palette size. *)
 
-val circle_palette: t -> int -> int32
+val circle_palette: t -> int -> t
 (**[circle_palette pal offset] returns a new palette with entries rotated to offset*)
 
-val update_entry: t -> int -> int32
+val update_entry: t -> int -> t
 (** [update_entry pal index new_color] checks for the index then returns a new palette with the entry at [index] updated to [new_color]. *)
 >>>>>>> 0dabb1a (feat(screen, palette): enable dynamic palette updates for retro effects)

--- a/src/palette.mli
+++ b/src/palette.mli
@@ -70,5 +70,5 @@ val index_to_rgb: t -> int -> int32
 val circle_palette: t -> int -> t
 (**[circle_palette pal offset] returns a new palette with entries rotated to offset*)
 
-val updated_entry : t -> int -> int32 -> t
+val updated_entry : t -> int -> (int * int * int) -> t
 (** [updated_entry pal index new_color] checks for the index then returns a new palette with the entry at [index] updated to [new_color]. *)

--- a/src/screen.ml
+++ b/src/screen.ml
@@ -5,6 +5,7 @@ type t = {
   scale           : int ;
   palette         : Palette.t ;
   font            : Font.t option;
+  dirty           : bool;
 }
 
 
@@ -12,16 +13,16 @@ let create (width : int) (height : int) (scale : int) (palette : Palette.t) : t 
   if scale <= 0 then raise (Invalid_argument "Invalid scale");
   if width <= 0 then raise (Invalid_argument "Invalid width");
   if height <= 0 then raise (Invalid_argument "Invalid height");
-  { width ; height ; scale ; palette ; font = None}
+  { width ; height ; scale ; palette ; font = None; dirty = true}
 
-let update (screen : t) (new_palette : Palette.t) : t =
-{screen with palette = new_palette}
+let update_palette (screen : t) (new_palette : Palette.t) : t =
+  { screen with palette = new_palette; dirty = true }
 
 let create_with_font (width : int) (height : int) (scale : int) (font : Font.t) (palette : Palette.t) : t =
   if scale <= 0 then raise (Invalid_argument "Invalid scale");
   if width <= 0 then raise (Invalid_argument "Invalid width");
   if height <= 0 then raise (Invalid_argument "Invalid height");
-  { width ; height ; scale ; palette ; font = Some font }
+  { width ; height ; scale ; palette ; font = Some font; dirty = true }
 
 let dimensions (screen : t) : int * int =
   screen.width, screen.height
@@ -34,3 +35,9 @@ let font (screen : t) : Font.t option =
 
 let scale (screen : t) : int =
   screen.scale
+
+let is_dirty (screen : t) : bool =
+  screen.dirty
+
+let clear_dirty (screen : t) : t =
+  { screen with dirty = false }

--- a/src/screen.ml
+++ b/src/screen.ml
@@ -3,9 +3,9 @@ type t = {
   width           : int ;
   height          : int ;
   scale           : int ;
-  palette         : Palette.t ;
+  mutable palette         : Palette.t ;
   font            : Font.t option;
-  dirty           : bool;
+  mutable dirty           : bool;
 }
 
 
@@ -15,8 +15,9 @@ let create (width : int) (height : int) (scale : int) (palette : Palette.t) : t 
   if height <= 0 then raise (Invalid_argument "Invalid height");
   { width ; height ; scale ; palette ; font = None; dirty = true}
 
-let update_palette (screen : t) (new_palette : Palette.t) : t =
-  { screen with palette = new_palette; dirty = true }
+  let update_palette (screen : t) (new_palette : Palette.t) : unit =
+    screen.palette <- new_palette;
+    screen.dirty <- true  
 
 let create_with_font (width : int) (height : int) (scale : int) (font : Font.t) (palette : Palette.t) : t =
   if scale <= 0 then raise (Invalid_argument "Invalid scale");
@@ -39,5 +40,5 @@ let scale (screen : t) : int =
 let is_dirty (screen : t) : bool =
   screen.dirty
 
-let clear_dirty (screen : t) : t =
-  { screen with dirty = false }
+let clear_dirty (screen : t) : unit =
+  screen.dirty <- false

--- a/src/screen.ml
+++ b/src/screen.ml
@@ -8,7 +8,6 @@ type t = {
   mutable dirty           : bool;
 }
 
-
 let create (width : int) (height : int) (scale : int) (palette : Palette.t) : t =
   if scale <= 0 then raise (Invalid_argument "Invalid scale");
   if width <= 0 then raise (Invalid_argument "Invalid width");

--- a/src/screen.ml
+++ b/src/screen.ml
@@ -14,6 +14,9 @@ let create (width : int) (height : int) (scale : int) (palette : Palette.t) : t 
   if height <= 0 then raise (Invalid_argument "Invalid height");
   { width ; height ; scale ; palette ; font = None}
 
+let update (screen : t) (new_palette : Palette.t) : t =
+{screen with palette = new_palette}
+
 let create_with_font (width : int) (height : int) (scale : int) (font : Font.t) (palette : Palette.t) : t =
   if scale <= 0 then raise (Invalid_argument "Invalid scale");
   if width <= 0 then raise (Invalid_argument "Invalid width");

--- a/src/screen.mli
+++ b/src/screen.mli
@@ -11,7 +11,7 @@ val create: int -> int -> int -> Palette.t -> t
     used when running will be indexed into the [palette] provided here. Raises [Invalid_argument] if
    the dimensions or scale are either zero or negative. *)
 
-val update_palette: t -> Palette.t -> t
+val update_palette: t -> Palette.t -> unit
 (**[update screen new_palette] creates a new screen with updated palette and marks the screen as dirty.*)
 
 val create_with_font: int -> int -> int -> Font.t -> Palette.t -> t
@@ -38,5 +38,5 @@ val font : t -> Font.t option
 val is_dirty : t -> bool
 (** [is_dirty screen] returns [true] if the screen is marked as dirty (needing redraw). *)
 
-val clear_dirty : t -> t
+val clear_dirty : t -> unit
 (** [clear_dirty screen] returns a new screen with the dirty flag cleared. *)

--- a/src/screen.mli
+++ b/src/screen.mli
@@ -11,8 +11,8 @@ val create: int -> int -> int -> Palette.t -> t
     used when running will be indexed into the [palette] provided here. Raises [Invalid_argument] if
    the dimensions or scale are either zero or negative. *)
 
-val update: t -> Palette.t -> t
-(**[update screen new_palette] creates a new screen with updated palette*)
+val update_palette: t -> Palette.t -> t
+(**[update screen new_palette] creates a new screen with updated palette and marks the screen as dirty.*)
 
 val create_with_font: int -> int -> int -> Font.t -> Palette.t -> t
 (** [create width height scale font palette] Creates a new screen of the specified size [width] x [height],
@@ -34,3 +34,9 @@ val scale : t -> int
 
 val font : t -> Font.t option
 (** [font screen] Returns the font associated with the [screen] if one was provided, or [None] otherwise. *)
+
+val is_dirty : t -> bool
+(** [is_dirty screen] returns [true] if the screen is marked as dirty (needing redraw). *)
+
+val clear_dirty : t -> t
+(** [clear_dirty screen] returns a new screen with the dirty flag cleared. *)

--- a/src/screen.mli
+++ b/src/screen.mli
@@ -11,6 +11,9 @@ val create: int -> int -> int -> Palette.t -> t
     used when running will be indexed into the [palette] provided here. Raises [Invalid_argument] if
    the dimensions or scale are either zero or negative. *)
 
+val update: t -> Palette.t -> t
+(**[update screen new_palette] creates a new screen with updated palette*)
+
 val create_with_font: int -> int -> int -> Font.t -> Palette.t -> t
 (** [create width height scale font palette] Creates a new screen of the specified size [width] x [height],
     and it will be rendered in a window scaled up by the [scale] factor provided. A font to be

--- a/test/test_palette.ml
+++ b/test/test_palette.ml
@@ -2,7 +2,7 @@ open Claudius
 open OUnit2
 
 let test_basic_palette_of_ints _ =
-  let cols = [0x000000 ; 0xFF0000 ; 0x00FF00 ; 0x0000FF ; 0xFFFFFF] in
+  let cols = [0x000000; 0xFF0000; 0x00FF00; 0x0000FF; 0xFFFFFF] in
   let pal = Palette.of_list cols in
   assert_equal ~msg:"Palette size" (List.length cols) (Palette.size pal);
   List.iteri (fun i c ->
@@ -55,10 +55,9 @@ let test_generate_microsoft_vga_palette_creation _ =
 let test_plasma_palette_creation _ =
   let pal = Palette.generate_plasma_palette 16 in
   assert_equal ~msg:"Palette size" 16 (Palette.size pal);
-  (* weak sauce perhaps, but just check there's no black/white here, i.e., not a mono palette *)
   List.iter (fun c ->
-    assert_bool "Colour not black" (0x000000 != c);
-    assert_bool "Colour not white" (0xFFFFFF != c);
+    assert_bool "Colour not black" (0x000000 <> c);
+    assert_bool "Colour not white" (0xFFFFFF <> c);
   ) (Palette.to_list pal)
 
 let test_mono_palette_creation _ =
@@ -76,18 +75,18 @@ let test_mono_palette_creation _ =
   ) (Palette.to_list pal)
 
 let test_create_empty_palette_from_list _ =
-  assert_raises (Invalid_argument "Palette size must not be zero or negativelyative") (fun _ -> Palette.of_list [])
+  assert_raises (Invalid_argument "Palette size must not be zero or negative") (fun () -> Palette.of_list [])
 
 let test_create_empty_plasma _ =
-  assert_raises (Invalid_argument "Palette size must not be zero or negativelyative") (fun _ -> Palette.generate_plasma_palette 0);
-  assert_raises (Invalid_argument "Palette size must not be zero or negativelyative") (fun _ -> Palette.generate_plasma_palette (-1))
+  assert_raises (Invalid_argument "Palette size must not be zero or negative") (fun () -> Palette.generate_plasma_palette 0);
+  assert_raises (Invalid_argument "Palette size must not be zero or negative") (fun () -> Palette.generate_plasma_palette (-1))
 
 let test_create_empty_mono _ =
-  assert_raises (Invalid_argument "Palette size must not be zero or negativelyative") (fun _ -> Palette.generate_mono_palette 0);
-  assert_raises (Invalid_argument "Palette size must not be zero or negativelyative") (fun _ -> Palette.generate_mono_palette (-1))
+  assert_raises (Invalid_argument "Palette size must not be zero or negative") (fun () -> Palette.generate_mono_palette 0);
+  assert_raises (Invalid_argument "Palette size must not be zero or negative") (fun () -> Palette.generate_mono_palette (-1))
 
 let test_load_tic80_palette _ =
-  let cols = [0x000000 ; 0xFF0000 ; 0x00FF00 ; 0x0000FF ; 0xFFFFFF] in
+  let cols = [0x000000; 0xFF0000; 0x00FF00; 0x0000FF; 0xFFFFFF] in
   let pal = Palette.load_tic80_palette "000:000000FF000000FF000000FFFFFFFF" in
   assert_equal ~msg:"Palette size" (List.length cols) (Palette.size pal);
   List.iteri (fun i c ->
@@ -96,13 +95,13 @@ let test_load_tic80_palette _ =
   ) cols
 
 let test_fail_with_invalid_palette_byte_count _ =
-  assert_raises (Invalid_argument "String size not a multiple of 6 chars per colour") (fun _ -> Palette.load_tic80_palette "000:000000FF000000FF000000FFFFFFF")
+  assert_raises (Invalid_argument "String size not a multiple of 6 chars per colour") (fun () -> Palette.load_tic80_palette "000:000000FF000000FF000000FFFFFFF")
 
 let test_fail_load_empty_tic80_palette _ =
-  assert_raises (Invalid_argument "Palette size must not be zero or negativelyative") (fun _ -> Palette.load_tic80_palette "000:")
+  assert_raises (Invalid_argument "Palette size must not be zero or negative") (fun () -> Palette.load_tic80_palette "000:")
 
 let test_palette_wrap_around _ =
-  let cols = [0x000000 ; 0xFF0000 ; 0x00FF00 ; 0x0000FF ; 0xFFFFFF] in
+  let cols = [0x000000; 0xFF0000; 0x00FF00; 0x0000FF; 0xFFFFFF] in
   let pal = Palette.of_list cols in
   for idx = -5 to -1 do
     let v = Palette.index_to_rgb pal idx in
@@ -127,72 +126,60 @@ let test_valid_lospec_palette _ =
 
 let test_invalid_lospec_palette _ =
   let input = "#FF0000\nGGGGGG\n00FF00" in
-  assert_raises (Invalid_argument "Failed to parse hex color: \"GGGGGG\"")
-    (fun () -> ignore (Palette.load_lospec_palette input))
+  assert_raises (Invalid_argument "Failed to parse hex color: \"GGGGGG\"") (fun () -> ignore (Palette.load_lospec_palette input))
 
 let test_empty_lospec_palette _ =
-  assert_raises (Invalid_argument "Palette size must not be zero or invalid HEX values")
-    (fun () -> ignore (Palette.load_lospec_palette ""))
+  assert_raises (Invalid_argument "Palette size must not be zero or invalid HEX values") (fun () -> ignore (Palette.load_lospec_palette ""))
 
 let test_circle_palette_valid _ =
   let original = Palette.of_list [0x000000; 0x111111; 0x222222; 0x333333] in
   let rotated_positively = Palette.circle_palette original 1 in
-
   assert_equal ~msg:"Rotated palette (positively offset) size" (Palette.size original) (Palette.size rotated_positively);
-  assert_equal ~msg:"Positively offset, element 0" 
-  (Palette.index_to_rgb original 1) (Palette.index_to_rgb rotated_positively 0);
-  assert_equal ~msg:"Positively offset, element 1" 
-  (Palette.index_to_rgb original 2) (Palette.index_to_rgb rotated_positively 1);
-  assert_equal ~msg:"Positively offset, element 2" 
-  (Palette.index_to_rgb original 3) (Palette.index_to_rgb rotated_positively 2);
-  assert_equal ~msg:"Positively offset, element 3" 
-  (Palette.index_to_rgb original 0) (Palette.index_to_rgb rotated_positively 3);
-
+  assert_equal ~msg:"Positively offset, element 0" (Palette.index_to_rgb original 1) (Palette.index_to_rgb rotated_positively 0);
+  assert_equal ~msg:"Positively offset, element 1" (Palette.index_to_rgb original 2) (Palette.index_to_rgb rotated_positively 1);
+  assert_equal ~msg:"Positively offset, element 2" (Palette.index_to_rgb original 3) (Palette.index_to_rgb rotated_positively 2);
+  assert_equal ~msg:"Positively offset, element 3" (Palette.index_to_rgb original 0) (Palette.index_to_rgb rotated_positively 3);
   let rotated_negatively = Palette.circle_palette original (-1) in
-  assert_equal ~msg:"Rotated palette (positively offset) size" (Palette.size original) (Palette.size rotated_negatively);
-  assert_equal ~msg:"negatively offset, element 0" 
-  (Palette.index_to_rgb original 3) (Palette.index_to_rgb rotated_negatively 0);
-  assert_equal ~msg:"negatively offset, element 1" 
-  (Palette.index_to_rgb original 0) (Palette.index_to_rgb rotated_negatively 1);
-  assert_equal ~msg:"negatively offset, element 2" 
-  (Palette.index_to_rgb original 1) (Palette.index_to_rgb rotated_negatively 2);
-  assert_equal ~msg:"negatively offset, element 3"
-  (Palette.index_to_rgb original 2) (Palette.index_to_rgb rotated_negatively 3);
-    
+  assert_equal ~msg:"Rotated palette (negatively offset) size" (Palette.size original) (Palette.size rotated_negatively);
+  assert_equal ~msg:"Negatively offset, element 0" (Palette.index_to_rgb original 3) (Palette.index_to_rgb rotated_negatively 0);
+  assert_equal ~msg:"Negatively offset, element 1" (Palette.index_to_rgb original 0) (Palette.index_to_rgb rotated_negatively 1);
+  assert_equal ~msg:"Negatively offset, element 2" (Palette.index_to_rgb original 1) (Palette.index_to_rgb rotated_negatively 2);
+  assert_equal ~msg:"Negatively offset, element 3" (Palette.index_to_rgb original 2) (Palette.index_to_rgb rotated_negatively 3)
+
 let test_updated_entry_valid _ =
-  let original = Palette.of_list [ 0xAAAAAAl; 0xBBBBBBl; 0xCCCCCCl; 0xDDDDDDl ] in
+  let original = Palette.of_list [0xAAAAAA; 0xBBBBBB; 0xCCCCCC; 0xDDDDDD] in
   let new_palette = Palette.updated_entry original 2 (0x12, 0x34, 0x56) in
-  let expected_color = Int32.of_int ((0x12 lsl 16) lor (0x34 lsl 8) lor 0x56) in
-  assert_equal ~msg:"Updated entry at index 2" expected_color new_palette.(2);
-  assert_equal ~msg:"Index 0 unchanged" original.(0) new_palette.(0);
-  assert_equal ~msg:"Index 1 unchanged" original.(1) new_palette.(1);
-  assert_equal ~msg:"Index 3 unchanged" original.(3) new_palette.(3);
+  let expected_color = Int32.of_int ((0x12 * 65536) lor (0x34 * 256) lor 0x56) in
+  assert_equal ~msg:"Updated entry at index 2" expected_color  (Palette.index_to_rgb new_palette 2);
+  assert_equal ~msg:"Index 0 unchanged" (Palette.index_to_rgb original 0) (Palette.index_to_rgb new_palette 0);
+  assert_equal ~msg:"Index 1 unchanged" (Palette.index_to_rgb original 1) (Palette.index_to_rgb new_palette 1);
+  assert_equal ~msg:"Index 3 unchanged" (Palette.index_to_rgb original 3) (Palette.index_to_rgb new_palette 3)
 
 let test_updated_entry_invalid _ =
-  let original = Palette.of_list [ 0xAAAAAAl; 0xBBBBBBl; 0xCCCCCCl; 0xDDDDDDl ] in
+  let original = Palette.of_list [0xAAAAAA; 0xBBBBBB; 0xCCCCCC; 0xDDDDDD] in
   assert_raises (Invalid_argument "Invalid palette index")
-  (fun () -> Palette.updated_entry original (-1) (0x12, 0x34, 0x56));
+    (fun () -> Palette.updated_entry original (-1) (0x12, 0x34, 0x56));
   assert_raises (Invalid_argument "Invalid palette index")
-  (fun () -> Palette.updated_entry original 4 (0x12, 0x34, 0x56))
+    (fun () -> Palette.updated_entry original 4 (0x12, 0x34, 0x56))
 
 let suite =
   "PaletteTests" >::: [
-    "Test simple palette set up" >:: test_basic_palette_of_ints ;
+    "Test simple palette set up" >:: test_basic_palette_of_ints;
     "Test generate mac palette" >:: test_generate_mac_palette_creation;
     "Test generate sweetie16 palette" >:: test_generate_sweetie16_palette;
     "Test linear palette" >:: test_generate_linear_palette;
     "Test vapour wave creation" >:: test_generate_vapour_wave_creation;
     "Test classic vga palette creation" >:: test_generate_classic_vga_palette_creation;
     "Test microsoft vga palette creation" >:: test_generate_microsoft_vga_palette_creation;
-    "Test plasma palette creation" >:: test_plasma_palette_creation ;
-    "Test mono creation" >:: test_mono_palette_creation ;
-    "Test fail to make empty palette" >:: test_create_empty_palette_from_list ;
-    "Test fail to make zero entry plasma palette" >:: test_create_empty_plasma ;
-    "Test fail to make zero entry mono palette" >:: test_create_empty_mono ;
-    "Test load tic80 palette string" >:: test_load_tic80_palette ;
-    "Test fail invalid tic80 palette" >:: test_fail_with_invalid_palette_byte_count ;
-    "Test fail empty tic80 palette" >:: test_fail_load_empty_tic80_palette ;
-    "Test palette wrap around" >:: test_palette_wrap_around ;
+    "Test plasma palette creation" >:: test_plasma_palette_creation;
+    "Test mono creation" >:: test_mono_palette_creation;
+    "Test fail to make empty palette" >:: test_create_empty_palette_from_list;
+    "Test fail to make zero entry plasma palette" >:: test_create_empty_plasma;
+    "Test fail to make zero entry mono palette" >:: test_create_empty_mono;
+    "Test load tic80 palette string" >:: test_load_tic80_palette;
+    "Test fail invalid tic80 palette" >:: test_fail_with_invalid_palette_byte_count;
+    "Test fail empty tic80 palette" >:: test_fail_load_empty_tic80_palette;
+    "Test palette wrap around" >:: test_palette_wrap_around;
     "Valid Lospec palette" >:: test_valid_lospec_palette;
     "Invalid Lospec palette" >:: test_invalid_lospec_palette;
     "Empty Lospec palette" >:: test_empty_lospec_palette;

--- a/test/test_palette.ml
+++ b/test/test_palette.ml
@@ -160,16 +160,16 @@ let test_circle_palette_valid _ =
   (Palette.index_to_rgb original 2) (Palette.index_to_rgb rotated_negatively 3);
     
 let test_updated_entry_valid _ =
-  let original = [| 0xAAAAAAl; 0xBBBBBBl; 0xCCCCCCl; 0xDDDDDDl |] in
+  let original = Palette.of_list [ 0xAAAAAAl; 0xBBBBBBl; 0xCCCCCCl; 0xDDDDDDl ] in
   let new_palette = Palette.updated_entry original 2 (0x12, 0x34, 0x56) in
   let expected_color = Int32.of_int ((0x12 lsl 16) lor (0x34 lsl 8) lor 0x56) in
   assert_equal ~msg:"Updated entry at index 2" expected_color new_palette.(2);
   assert_equal ~msg:"Index 0 unchanged" original.(0) new_palette.(0);
   assert_equal ~msg:"Index 1 unchanged" original.(1) new_palette.(1);
-  assert_equal ~msg:"Index 3 unchanged" original.(3) new_palette.(3)
+  assert_equal ~msg:"Index 3 unchanged" original.(3) new_palette.(3);
 
 let test_updated_entry_invalid _ =
-  let original = [| 0xAAAAAAl; 0xBBBBBBl; 0xCCCCCCl; 0xDDDDDDl |] in
+  let original = Palette.of_list [ 0xAAAAAAl; 0xBBBBBBl; 0xCCCCCCl; 0xDDDDDDl ] in
   assert_raises (Invalid_argument "Invalid palette index")
   (fun () -> Palette.updated_entry original (-1) (0x12, 0x34, 0x56));
   assert_raises (Invalid_argument "Invalid palette index")

--- a/test/test_palette.ml
+++ b/test/test_palette.ml
@@ -135,7 +135,7 @@ let test_empty_lospec_palette _ =
     (fun () -> ignore (Palette.load_lospec_palette ""))
 
 let test_circle_palette_valid _ =
-  let original = [| 0x000000l; 0x111111l; 0x222222l; 0x333333l |] in
+  let original = Palette.of_list [0x000000; 0x111111; 0x222222; 0x333333]
   let rotated_positively = Palette.circle_palette original 1 in
   assert_equal ~msg:"Rotated palette (positively offset) size" (Array.length original) (Array.length rotated_positively);
   assert_equal ~msg:"Positively offset, element 0" original.(1) rotated_positively.(0);

--- a/test/test_palette.ml
+++ b/test/test_palette.ml
@@ -158,6 +158,13 @@ let test_updated_entry_valid _ =
   assert_equal ~msg:"Index 1 unchanged" original.(1) new_palette.(1);
   assert_equal ~msg:"Index 3 unchanged" original.(3) new_palette.(3)
 
+let test_updated_entry_invalid _ =
+  let original = [| 0xAAAAAAl; 0xBBBBBBl; 0xCCCCCCl; 0xDDDDDDl |] in
+  assert_raises (Invalid_argument "Invalid palette index")
+  (fun () -> updated_entry original (-1) (0x12, 0x34, 0x56));
+  assert_raises (Invalid_argument "Invalid palette index")
+  (fun () -> updated_entry original 4 (0x12, 0x34, 0x56))
+
 let suite =
   "PaletteTests" >::: [
     "Test simple palette set up" >:: test_basic_palette_of_ints ;
@@ -179,7 +186,9 @@ let suite =
     "Valid Lospec palette" >:: test_valid_lospec_palette;
     "Invalid Lospec palette" >:: test_invalid_lospec_palette;
     "Empty Lospec palette" >:: test_empty_lospec_palette;
-
+    "Test circle_palette (valid)" >:: test_circle_palette_valid;
+    "Test updated_entry (valid)" >:: test_updated_entry_valid;
+    "Test updated_entry (invalid)" >:: test_updated_entry_invalid;
   ]
 
 let () =

--- a/test/test_palette.ml
+++ b/test/test_palette.ml
@@ -76,15 +76,15 @@ let test_mono_palette_creation _ =
   ) (Palette.to_list pal)
 
 let test_create_empty_palette_from_list _ =
-  assert_raises (Invalid_argument "Palette size must not be zero or negative") (fun _ -> Palette.of_list [])
+  assert_raises (Invalid_argument "Palette size must not be zero or negativelyative") (fun _ -> Palette.of_list [])
 
 let test_create_empty_plasma _ =
-  assert_raises (Invalid_argument "Palette size must not be zero or negative") (fun _ -> Palette.generate_plasma_palette 0);
-  assert_raises (Invalid_argument "Palette size must not be zero or negative") (fun _ -> Palette.generate_plasma_palette (-1))
+  assert_raises (Invalid_argument "Palette size must not be zero or negativelyative") (fun _ -> Palette.generate_plasma_palette 0);
+  assert_raises (Invalid_argument "Palette size must not be zero or negativelyative") (fun _ -> Palette.generate_plasma_palette (-1))
 
 let test_create_empty_mono _ =
-  assert_raises (Invalid_argument "Palette size must not be zero or negative") (fun _ -> Palette.generate_mono_palette 0);
-  assert_raises (Invalid_argument "Palette size must not be zero or negative") (fun _ -> Palette.generate_mono_palette (-1))
+  assert_raises (Invalid_argument "Palette size must not be zero or negativelyative") (fun _ -> Palette.generate_mono_palette 0);
+  assert_raises (Invalid_argument "Palette size must not be zero or negativelyative") (fun _ -> Palette.generate_mono_palette (-1))
 
 let test_load_tic80_palette _ =
   let cols = [0x000000 ; 0xFF0000 ; 0x00FF00 ; 0x0000FF ; 0xFFFFFF] in
@@ -99,7 +99,7 @@ let test_fail_with_invalid_palette_byte_count _ =
   assert_raises (Invalid_argument "String size not a multiple of 6 chars per colour") (fun _ -> Palette.load_tic80_palette "000:000000FF000000FF000000FFFFFFF")
 
 let test_fail_load_empty_tic80_palette _ =
-  assert_raises (Invalid_argument "Palette size must not be zero or negative") (fun _ -> Palette.load_tic80_palette "000:")
+  assert_raises (Invalid_argument "Palette size must not be zero or negativelyative") (fun _ -> Palette.load_tic80_palette "000:")
 
 let test_palette_wrap_around _ =
   let cols = [0x000000 ; 0xFF0000 ; 0x00FF00 ; 0x0000FF ; 0xFFFFFF] in
@@ -133,6 +133,30 @@ let test_invalid_lospec_palette _ =
 let test_empty_lospec_palette _ =
   assert_raises (Invalid_argument "Palette size must not be zero or invalid HEX values")
     (fun () -> ignore (Palette.load_lospec_palette ""))
+
+let test_circle_palette_valid _ =
+  let original = [| 0x000000l; 0x111111l; 0x222222l; 0x333333l |] in
+  let rotated_positively = circle_palette original 1 in
+  assert_equal ~msg:"Rotated palette (positively offset) size" (Array.length original) (Array.length rotated_positively);
+  assert_equal ~msg:"Positively offset, element 0" original.(1) rotated_positively.(0);
+  assert_equal ~msg:"Positively offset, element 1" original.(2) rotated_positively.(1);
+  assert_equal ~msg:"Positively offset, element 2" original.(3) rotated_positively.(2);
+  assert_equal ~msg:"Positively offset, element 3" original.(0) rotated_positively.(3);
+  let rotated_negatively = circle_palette original (-1) in
+  assert_equal ~msg:"Rotated palette (negatively offset) size" (Array.length original) (Array.length rotated_negatively);
+  assert_equal ~msg:"negatively offset, element 0" original.(3) rotated_negatively.(0);
+  assert_equal ~msg:"negatively offset, element 1" original.(0) rotated_negatively.(1);
+  assert_equal ~msg:"negatively offset, element 2" original.(1) rotated_negatively.(2);
+  assert_equal ~msg:"negatively offset, element 3" original.(2) rotated_negatively.(3)
+    
+let test_updated_entry_valid _ =
+  let original = [| 0xAAAAAAl; 0xBBBBBBl; 0xCCCCCCl; 0xDDDDDDl |] in
+  let new_palette = updated_entry original 2 (0x12, 0x34, 0x56) in
+  let expected_color = Int32.of_int ((0x12 lsl 16) lor (0x34 lsl 8) lor 0x56) in
+  assert_equal ~msg:"Updated entry at index 2" expected_color new_palette.(2);
+  assert_equal ~msg:"Index 0 unchanged" original.(0) new_palette.(0);
+  assert_equal ~msg:"Index 1 unchanged" original.(1) new_palette.(1);
+  assert_equal ~msg:"Index 3 unchanged" original.(3) new_palette.(3)
 
 let suite =
   "PaletteTests" >::: [

--- a/test/test_palette.ml
+++ b/test/test_palette.ml
@@ -75,7 +75,7 @@ let test_mono_palette_creation _ =
   ) (Palette.to_list pal)
 
 let test_create_empty_palette_from_list _ =
-  assert_raises (Invalid_argument "Palette size must not be zero or negative") (fun () -> Palette.of_list [])
+  assert_raises (Invalid_argument "Palette size must not be zero or negative") (fun _ -> Palette.of_list [])
 
 let test_create_empty_plasma _ =
   assert_raises (Invalid_argument "Palette size must not be zero or negative") (fun () -> Palette.generate_plasma_palette 0);

--- a/test/test_palette.ml
+++ b/test/test_palette.ml
@@ -136,13 +136,13 @@ let test_empty_lospec_palette _ =
 
 let test_circle_palette_valid _ =
   let original = [| 0x000000l; 0x111111l; 0x222222l; 0x333333l |] in
-  let rotated_positively = circle_palette original 1 in
+  let rotated_positively = Palette.circle_palette original 1 in
   assert_equal ~msg:"Rotated palette (positively offset) size" (Array.length original) (Array.length rotated_positively);
   assert_equal ~msg:"Positively offset, element 0" original.(1) rotated_positively.(0);
   assert_equal ~msg:"Positively offset, element 1" original.(2) rotated_positively.(1);
   assert_equal ~msg:"Positively offset, element 2" original.(3) rotated_positively.(2);
   assert_equal ~msg:"Positively offset, element 3" original.(0) rotated_positively.(3);
-  let rotated_negatively = circle_palette original (-1) in
+  let rotated_negatively = Palette.circle_palette original (-1) in
   assert_equal ~msg:"Rotated palette (negatively offset) size" (Array.length original) (Array.length rotated_negatively);
   assert_equal ~msg:"negatively offset, element 0" original.(3) rotated_negatively.(0);
   assert_equal ~msg:"negatively offset, element 1" original.(0) rotated_negatively.(1);
@@ -151,7 +151,7 @@ let test_circle_palette_valid _ =
     
 let test_updated_entry_valid _ =
   let original = [| 0xAAAAAAl; 0xBBBBBBl; 0xCCCCCCl; 0xDDDDDDl |] in
-  let new_palette = updated_entry original 2 (0x12, 0x34, 0x56) in
+  let new_palette = Palette.updated_entry original 2 (0x12, 0x34, 0x56) in
   let expected_color = Int32.of_int ((0x12 lsl 16) lor (0x34 lsl 8) lor 0x56) in
   assert_equal ~msg:"Updated entry at index 2" expected_color new_palette.(2);
   assert_equal ~msg:"Index 0 unchanged" original.(0) new_palette.(0);
@@ -161,9 +161,9 @@ let test_updated_entry_valid _ =
 let test_updated_entry_invalid _ =
   let original = [| 0xAAAAAAl; 0xBBBBBBl; 0xCCCCCCl; 0xDDDDDDl |] in
   assert_raises (Invalid_argument "Invalid palette index")
-  (fun () -> updated_entry original (-1) (0x12, 0x34, 0x56));
+  (fun () -> Palette.updated_entry original (-1) (0x12, 0x34, 0x56));
   assert_raises (Invalid_argument "Invalid palette index")
-  (fun () -> updated_entry original 4 (0x12, 0x34, 0x56))
+  (fun () -> Palette.updated_entry original 4 (0x12, 0x34, 0x56))
 
 let suite =
   "PaletteTests" >::: [

--- a/test/test_palette.ml
+++ b/test/test_palette.ml
@@ -135,19 +135,29 @@ let test_empty_lospec_palette _ =
     (fun () -> ignore (Palette.load_lospec_palette ""))
 
 let test_circle_palette_valid _ =
-  let original = Palette.of_list [0x000000; 0x111111; 0x222222; 0x333333]
+  let original = Palette.of_list [0x000000; 0x111111; 0x222222; 0x333333] in
   let rotated_positively = Palette.circle_palette original 1 in
-  assert_equal ~msg:"Rotated palette (positively offset) size" (Array.length original) (Array.length rotated_positively);
-  assert_equal ~msg:"Positively offset, element 0" original.(1) rotated_positively.(0);
-  assert_equal ~msg:"Positively offset, element 1" original.(2) rotated_positively.(1);
-  assert_equal ~msg:"Positively offset, element 2" original.(3) rotated_positively.(2);
-  assert_equal ~msg:"Positively offset, element 3" original.(0) rotated_positively.(3);
+
+  assert_equal ~msg:"Rotated palette (positively offset) size" (Palette.size original) (Palette.size rotated_positively);
+  assert_equal ~msg:"Positively offset, element 0" 
+  (Palette.index_to_rgb original 1) (Palette.index_to_rgb rotated_positively 0);
+  assert_equal ~msg:"Positively offset, element 1" 
+  (Palette.index_to_rgb original 2) (Palette.index_to_rgb rotated_positively 1);
+  assert_equal ~msg:"Positively offset, element 2" 
+  (Palette.index_to_rgb original 3) (Palette.index_to_rgb rotated_positively 2);
+  assert_equal ~msg:"Positively offset, element 3" 
+  (Palette.index_to_rgb original 0) (Palette.index_to_rgb rotated_positively 3);
+
   let rotated_negatively = Palette.circle_palette original (-1) in
-  assert_equal ~msg:"Rotated palette (negatively offset) size" (Array.length original) (Array.length rotated_negatively);
-  assert_equal ~msg:"negatively offset, element 0" original.(3) rotated_negatively.(0);
-  assert_equal ~msg:"negatively offset, element 1" original.(0) rotated_negatively.(1);
-  assert_equal ~msg:"negatively offset, element 2" original.(1) rotated_negatively.(2);
-  assert_equal ~msg:"negatively offset, element 3" original.(2) rotated_negatively.(3)
+  assert_equal ~msg:"Rotated palette (positively offset) size" (Palette.size original) (Palette.size rotated_negatively);
+  assert_equal ~msg:"negatively offset, element 0" 
+  (Palette.index_to_rgb original 3) (Palette.index_to_rgb rotated_negatively 0);
+  assert_equal ~msg:"negatively offset, element 1" 
+  (Palette.index_to_rgb original 0) (Palette.index_to_rgb rotated_negatively 1);
+  assert_equal ~msg:"negatively offset, element 2" 
+  (Palette.index_to_rgb original 1) (Palette.index_to_rgb rotated_negatively 2);
+  assert_equal ~msg:"negatively offset, element 3"
+  (Palette.index_to_rgb original 2) (Palette.index_to_rgb rotated_negatively 3);
     
 let test_updated_entry_valid _ =
   let original = [| 0xAAAAAAl; 0xBBBBBBl; 0xCCCCCCl; 0xDDDDDDl |] in

--- a/test/test_screen.ml
+++ b/test/test_screen.ml
@@ -20,11 +20,24 @@ let test_fail_invalid_dimensions _ =
   assert_raises (Invalid_argument "Invalid height") (fun _ -> Screen.create 10 (-10) 2 palette);
   assert_raises (Invalid_argument "Invalid width") (fun _ -> Screen.create (-10) 10 2 palette)
 
+let test_update_palette _ =
+  let initial_palette = Palette.generate_mono_palette 2 in
+  let screen = Screen.create 640 480 2 initial_palette in
+  Screen.clear_dirty screen;
+  assert_equal ~msg:"Dirty flag should be false after clearing" false (Screen.is_dirty screen);
+  let new_palette = Palette.generate_plasma_palette 2 in
+   Screen.update_palette screen new_palette;
+   assert_equal ~msg:"Palette should be updated" new_palette (Screen.palette screen);
+   assert_equal ~msg:"Dirty flag should be true after update" true (Screen.is_dirty screen);
+   Screen.clear_dirty screen;
+   assert_equal ~msg:"Dirty flag should be cleared" false (Screen.is_dirty screen)
+
 let suite =
   "Screen tests" >::: [
     "Test simple screen set up" >:: test_basic_screen_creation ;
     "Test fail with invalid scale" >:: test_fail_invalid_scale ;
     "Test fail with invalid dimensions" >:: test_fail_invalid_dimensions ;
+    "Test update palette">:: test_update_palette ;
   ]
 
 let () =


### PR DESCRIPTION
Partially Resolves #5 
 Traditionally, the palette is fixed at screen creation, which makes it difficult to implement dynamic effects like palette cycling or per-entry updates without redrawing the entire image. 
 - The `Screen.t` record now includes the palette as part of its state as seen from @mdales declaration.

So, I added:
 - A new function, `update`, allows us to update the palette while functionally retaining all other screen parameters.
 
In the Palette Module I:
- Added `cycle_palette` to rotate the palette entries by a given offset.
- Added `update_entry` to update a specific palette entry.

@mdales please I will appreciate your review