### PR TITLE
Added event-based input tracking alongside raw key states  

### DIFF
--- a/src/base.mli
+++ b/src/base.mli
@@ -9,8 +9,21 @@ module PlatformKey : module type of Keysdl
 type boot_func = Screen.t -> Framebuffer.t
 (** Function called once a start of run *)
 
-type tick_func = int -> Screen.t -> Framebuffer.t -> KeyCodeSet.t -> Framebuffer.t
-(** Function called once a frame during run *)
+(** A key event representing a key press or release. *)
+type key_event =
+  | KeyDown of Key.t  (** A key was pressed. *)
+  | KeyUp of Key.t    (** A key was released. *)
+
+(** The complete input state provided to each tick:
+    - [pressed] 
+    - [events]  *)
+
+type input_state = {
+  pressed : KeyCodeSet.t;
+  events : key_event list;
+}
+
+type tick_func = int -> Screen.t -> Framebuffer.t -> input_state -> Framebuffer.t
 
 val run: string -> boot_func option -> tick_func -> Screen.t -> unit
 (** [run title boot tick screen] Creates the runloop *)


### PR DESCRIPTION
@mdales I have tried fixing this issue and also raised a PR for the same. 
These are the changes that I have made to the base.ml and base.mli files to fix this issue properly - 
 - New Types
    -  We introduce a key_event variant with KeyDown and KeyUp constructors and an input_state record that contains:
         - pressed: the set of keys currently pressed.
         -  events: the list of key events that have occurred this frame.

- Updated Tick Function
   - The type of tick_func is changed so that it now receives an input_state value instead of just the raw set of pressed 
       keys. 
   - This lets users write tick functions that can choose to respond either to continuous key presses or to discrete key events.

- Event Polling
     - The helper function poll_all_events repeatedly calls Sdl.poll_event to process all events in the queue, updating the key set 
    and accumulating events. 
     - The resulting key set and event list are then packaged into an input_state record that is passed to tick.

This layered approach should satisfy both use cases without forcing a single paradigm on all users.