### PR TITLE
(feat): fixed track control changes

### DIFF
--- a/src/base.ml
+++ b/src/base.ml
@@ -9,10 +9,18 @@ end)
 module PlatformKey = Keysdl
 
 type boot_func = Screen.t -> Framebuffer.t
-type tick_func = int -> Screen.t -> Framebuffer.t -> KeyCodeSet.t -> Framebuffer.t
 
-type bitmap_t = (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Array1.t
+(* New types to provide both raw key state and key events *)
+type key_event =
+  | KeyDown of Key.t
+  | KeyUp of Key.t
 
+type input_state = {
+  pressed : KeyCodeSet.t;
+  events : key_event list;
+}
+
+type tick_func = int -> Screen.t -> Framebuffer.t -> input_state -> Framebuffer.t
 
 (* ----- *)
 
@@ -25,7 +33,8 @@ let sdl_init (width : int) (height : int) (title : string) (make_fullscreen : bo
   Sdl.create_renderer ~flags:Sdl.Renderer.(accelerated + presentvsync) w >>= fun r ->
   Sdl.show_cursor (not make_fullscreen) >|= fun _ -> (w, r)
 
-let framebuffer_to_bigarray (s : Screen.t) (buffer : Framebuffer.t) (bitmap : bitmap_t) =
+let framebuffer_to_bigarray (s : Screen.t) (buffer : Framebuffer.t)
+    (bitmap : (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Array1.t) =
   let palette = Screen.palette s in
   Array.iteri (fun y row ->
     Array.iteri (fun x pixel ->
@@ -33,7 +42,8 @@ let framebuffer_to_bigarray (s : Screen.t) (buffer : Framebuffer.t) (bitmap : bi
     ) row
   ) (Framebuffer.to_array buffer)
 
-let render_texture (r : Sdl.renderer) (texture : Sdl.texture) (s : Screen.t) (bitmap : bitmap_t) =
+let render_texture (r : Sdl.renderer) (texture : Sdl.texture)
+    (s : Screen.t) (bitmap : (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Array1.t) =
   let width, height = Screen.dimensions s in
   let scale = Screen.scale s in
   Sdl.render_clear r >>= fun () ->
@@ -42,6 +52,23 @@ let render_texture (r : Sdl.renderer) (texture : Sdl.texture) (s : Screen.t) (bi
   let dst = Sdl.Rect.create ~x:((ow - (width * scale)) / 2) ~y:((oh - (height * scale)) / 2) ~w:(width * scale) ~h:(height * scale) in
   Sdl.render_copy ~dst:dst r texture >|= fun () ->
   Sdl.render_present r
+
+(* A helper function that polls all pending SDL events,
+   updates the key set, and accumulates a list of key events. *)
+let rec poll_all_events keys events =
+  let e = Sdl.Event.create () in
+  match Sdl.poll_event (Some e) with
+  | true ->
+      (match Sdl.Event.(enum (get e typ)) with
+       | `Quit -> (true, keys, events)
+       | `Key_down ->
+           let key = PlatformKey.of_backend_keycode (Sdl.Event.(get e keyboard_keycode)) in
+           poll_all_events (KeyCodeSet.add key keys) (KeyDown key :: events)
+       | `Key_up ->
+           let key = PlatformKey.of_backend_keycode (Sdl.Event.(get e keyboard_keycode)) in
+           poll_all_events (KeyCodeSet.remove key keys) (KeyUp key :: events)
+       | _ -> poll_all_events keys events)
+  | false -> (false, keys, List.rev events)
 
 (* ----- *)
 
@@ -74,14 +101,18 @@ let run (title : string) (boot : boot_func option) (tick : tick_func) (s : Scree
       | Some bfunc -> bfunc s
       in
 
-      let e = Sdl.Event.create () in
 
       let rec loop (t : int) (prev_buffer : Framebuffer.t) (keys : KeyCodeSet.t) last_t =
         let now = Sdl.get_ticks () in
         let diff = Int32.(sub (of_int (1000 / 60)) (sub now last_t)) in
         if Int32.(compare diff zero) > 0 then Sdl.delay diff;
 
-        let updated_buffer = tick t s prev_buffer keys in
+            (* Process all events this frame *)
+            let exit, new_keys, events = poll_all_events keys [] in
+            let input_state = { pressed = new_keys; events = events } in
+
+            (* Call the tick function with the current input state *)
+            let updated_buffer = tick t s prev_buffer input_state in
 
         if (updated_buffer != prev_buffer) || (Framebuffer.is_dirty updated_buffer) then (
           framebuffer_to_bigarray s updated_buffer bitmap;
@@ -91,24 +122,11 @@ let run (title : string) (boot : boot_func option) (tick : tick_func) (s : Scree
           Framebuffer.clear_dirty updated_buffer
         );
 
-        let exit, keys =
-          match Sdl.poll_event (Some e) with
-          | true ->
-              (match Sdl.Event.(enum (get e typ)) with
-               | `Quit -> (true, keys)
-               | `Key_down ->
-                   let key = PlatformKey.of_backend_keycode (Sdl.Event.(get e keyboard_keycode)) in
-                   (false, KeyCodeSet.add key keys)
-               | `Key_up ->
-                   let key = PlatformKey.of_backend_keycode (Sdl.Event.(get e keyboard_keycode)) in
-                   (false, KeyCodeSet.remove key keys)
-               | _ -> (false, keys))
-          | false -> (false, keys)
-        in
-        if exit then () else loop (t + 1) updated_buffer keys now
-      in
-      loop 0 initial_buffer KeyCodeSet.empty Int32.zero;
-      Sdl.destroy_texture texture;
-      Sdl.destroy_renderer r;
-      Sdl.destroy_window w;
-      Sdl.quit ()
+            if exit then ()
+            else loop (t + 1) updated_buffer new_keys now
+          in
+          loop 0 initial_buffer KeyCodeSet.empty Int32.zero;
+          Sdl.destroy_texture texture;
+          Sdl.destroy_renderer r;
+          Sdl.destroy_window w;
+          Sdl.quit ()

--- a/src/base.mli
+++ b/src/base.mli
@@ -9,8 +9,21 @@ module PlatformKey : module type of Keysdl
 type boot_func = Screen.t -> Framebuffer.t
 (** Function called once a start of run *)
 
-type tick_func = int -> Screen.t -> Framebuffer.t -> KeyCodeSet.t -> Framebuffer.t
-(** Function called once a frame during run *)
+(** A key event representing a key press or release. *)
+type key_event =
+  | KeyDown of Key.t  (** A key was pressed. *)
+  | KeyUp of Key.t    (** A key was released. *)
+
+(** The complete input state provided to each tick:
+    - [pressed] 
+    - [events]  *)
+
+type input_state = {
+  pressed : KeyCodeSet.t;
+  events : key_event list;
+}
+
+type tick_func = int -> Screen.t -> Framebuffer.t -> input_state -> Framebuffer.t
 
 val run: string -> boot_func option -> tick_func -> Screen.t -> unit
 (** [run title boot tick screen] Creates the runloop *)

--- a/src/base.mli
+++ b/src/base.mli
@@ -6,24 +6,28 @@ module KeyCodeSet : Set.S with type elt = Key.t
 module PlatformKey : module type of Keysdl
 (** A module that provides platform-specific key handling, based on the [Keysdl] module. *)
 
-type boot_func = Screen.t -> Framebuffer.t
-(** Function called once a start of run *)
+module PlatformMouse : module type of Mousesdl
+(** A module that provides platform-specific mouse handling, based on the {!Mousesdl} module. *)
 
-(** A key event representing a key press or release. *)
 type key_event =
   | KeyDown of Key.t  (** A key was pressed. *)
   | KeyUp of Key.t    (** A key was released. *)
 
-(** The complete input state provided to each tick:
-    - [pressed] 
-    - [events]  *)
-
 type input_state = {
-  pressed : KeyCodeSet.t;
-  events : key_event list;
+  keys: KeyCodeSet.t;
+  events: key_event list;
+  mouse: Mouse.t;
 }
+(** Represents the current state of user input, including:
+    - [keys]: The set of currently pressed keys.
+    - [events]: The list of keyboard events that occurred this frame.
+    - [mouse]: The current state of the mouse, including position and button presses. *)
+
+type boot_func = Screen.t -> Framebuffer.t
+(** Function called once a start of run *)
 
 type tick_func = int -> Screen.t -> Framebuffer.t -> input_state -> Framebuffer.t
+(** Function called once a frame during run *)
 
 val run: string -> boot_func option -> tick_func -> Screen.t -> unit
 (** [run title boot tick screen] Creates the runloop *)


### PR DESCRIPTION
This PR fixes the issue #13 

@mdales I have tried fixing this issue and also raised a PR for the same. 
These are the changes that I have made to the base.ml and base.mli files to fix this issue properly - 
 - New Types
    -  We introduce a key_event variant with KeyDown and KeyUp constructors and an input_state record that contains:
         - pressed: the set of keys currently pressed.
         -  events: the list of key events that have occurred this frame.

- Updated Tick Function
   - The type of tick_func is changed so that it now receives an input_state value instead of just the raw set of pressed 
       keys. 
   - This lets users write tick functions that can choose to respond either to continuous key presses or to discrete key events.

- Event Polling
     - The helper function poll_all_events repeatedly calls Sdl.poll_event to process all events in the queue, updating the key set 
    and accumulating events. 
     - The resulting key set and event list are then packaged into an input_state record that is passed to tick.

This layered approach should satisfy both use cases without forcing a single paradigm on all users.