### PR TITLE
Create a purely functional tick function

### DIFF
--- a/src/base.ml
+++ b/src/base.ml
@@ -19,6 +19,8 @@ type tick_func = int -> Screen.t -> Framebuffer.t -> input_state -> Framebuffer.
 
 type bitmap_t = (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Array1.t
 
+type functional_tick_func = int -> Screen.t -> KeyCodeSet.t -> Primitives.t list
+
 (* ----- *)
 
 let (>>=) = Result.bind
@@ -129,3 +131,15 @@ let run (title : string) (boot : boot_func option) (tick : tick_func) (s : Scree
       Sdl.destroy_renderer r;
       Sdl.destroy_window w;
       Sdl.quit ()
+
+
+let run_functional (title : string) (tick_f : functional_tick_func) (s : Screen.t) =
+  let wrap_tick (t : int) (screen : Screen.t) (_prev_fb : Framebuffer.t) (input : input_state) : Framebuffer.t =
+    let primitives : Primitives.t list = tick_f t screen input.keys in
+    let width, height = Screen.dimensions screen in
+    let new_framebuffer = Framebuffer.init (width, height) (fun _x _y -> 0) in
+    Framebuffer.render new_framebuffer primitives;
+    new_framebuffer
+  in
+  run title None wrap_tick s
+      

--- a/src/base.ml
+++ b/src/base.ml
@@ -131,8 +131,7 @@ let run (title : string) (boot : boot_func option) (tick : tick_func) (s : Scree
       Sdl.destroy_renderer r;
       Sdl.destroy_window w;
       Sdl.quit ()
-
-
+      
 let run_functional (title : string) (tick_f : functional_tick_func) (s : Screen.t) =
   let wrap_tick (t : int) (screen : Screen.t) (_prev_fb : Framebuffer.t) (input : input_state) : Framebuffer.t =
     let primitives : Primitives.t list = tick_f t screen input.keys in

--- a/src/base.ml
+++ b/src/base.ml
@@ -131,14 +131,17 @@ let run (title : string) (boot : boot_func option) (tick : tick_func) (s : Scree
       Sdl.destroy_renderer r;
       Sdl.destroy_window w;
       Sdl.quit ()
-      
+
 let run_functional (title : string) (tick_f : functional_tick_func) (s : Screen.t) =
-  let wrap_tick (t : int) (screen : Screen.t) (_prev_fb : Framebuffer.t) (input : input_state) : Framebuffer.t =
+  let wrap_tick (t : int) (screen : Screen.t) (prev_framebuffer : Framebuffer.t) (input : input_state) : Framebuffer.t =
     let primitives : Primitives.t list = tick_f t screen input.keys in
-    let width, height = Screen.dimensions screen in
-    let new_framebuffer = Framebuffer.init (width, height) (fun _x _y -> 0) in
-    Framebuffer.render new_framebuffer primitives;
-    new_framebuffer
+    if primitives = [] then
+      prev_framebuffer
+    else
+      let width, height = Screen.dimensions screen in
+      let new_framebuffer = Framebuffer.init (width, height) (fun _x _y -> 0) in
+      Framebuffer.render new_framebuffer primitives;
+      new_framebuffer
   in
   run title None wrap_tick s
       

--- a/src/base.mli
+++ b/src/base.mli
@@ -25,8 +25,9 @@ type tick_func = int -> Screen.t -> Framebuffer.t -> input_state -> Framebuffer.
 
 type functional_tick_func = int -> Screen.t -> KeyCodeSet.t -> Primitives.t list
 
-
 val run: string -> boot_func option -> tick_func -> Screen.t -> unit
 (** [run title boot tick screen] Creates the runloop *)
 
 val run_functional : string -> functional_tick_func -> Screen.t -> unit
+(** [run_functional title tick_f screen] runs Claudius in a functional style. 
+- [tick_f] screen returns a list of primitives rather than a complete framebuffer.*)

--- a/src/base.mli
+++ b/src/base.mli
@@ -23,5 +23,10 @@ type boot_func = Screen.t -> Framebuffer.t
 type tick_func = int -> Screen.t -> Framebuffer.t -> input_state -> Framebuffer.t
 (** Function called once a frame during run *)
 
+type functional_tick_func = int -> Screen.t -> KeyCodeSet.t -> Primitives.t list
+
+
 val run: string -> boot_func option -> tick_func -> Screen.t -> unit
 (** [run title boot tick screen] Creates the runloop *)
+
+val run_functional : string -> functional_tick_func -> Screen.t -> unit


### PR DESCRIPTION
This PR Resolves #29 
Defined a  functional_tick_func type that takes a frame counter, int a screen and keyset, a wrapped_tick function converting the output tick_f a list of primitives to create a ne framebuffer framebuffer.render new_framebuffer primitives to draw primitives on it. Finally, calling run_functional calls the existing run function.

@mdales Followed what you said [here](https://github.com/claudiusFX/Claudius/issues/29#issuecomment-2782460518)