### PR TITLE
updated the type definition for the functional tick function. and the…

### DIFF
--- a/src/base.ml
+++ b/src/base.ml
@@ -19,7 +19,7 @@ type tick_func = int -> Screen.t -> Framebuffer.t -> input_state -> Framebuffer.
 
 type bitmap_t = (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Array1.t
 
-type functional_tick_func = int -> Screen.t -> KeyCodeSet.t -> Primitives.t list
+type functional_tick_func = int -> Screen.t -> input_state -> Primitives.t list
 
 (* ----- *)
 
@@ -134,7 +134,7 @@ let run (title : string) (boot : boot_func option) (tick : tick_func) (s : Scree
 
 let run_functional (title : string) (tick_f : functional_tick_func) (s : Screen.t) =
   let wrap_tick (t : int) (screen : Screen.t) (prev_framebuffer : Framebuffer.t) (input : input_state) : Framebuffer.t =
-    let primitives : Primitives.t list = tick_f t screen input.keys in
+    let primitives : Primitives.t list = tick_f t screen input in
     if primitives = [] then
       prev_framebuffer
     else

--- a/src/base.mli
+++ b/src/base.mli
@@ -23,7 +23,7 @@ type boot_func = Screen.t -> Framebuffer.t
 type tick_func = int -> Screen.t -> Framebuffer.t -> input_state -> Framebuffer.t
 (** Function called once a frame during run *)
 
-type functional_tick_func = int -> Screen.t -> KeyCodeSet.t -> Primitives.t list
+type functional_tick_func = int -> Screen.t -> input_state -> Primitives.t list
 
 val run: string -> boot_func option -> tick_func -> Screen.t -> unit
 (** [run title boot tick screen] Creates the runloop *)


### PR DESCRIPTION
 Updated the type definition for the functional tick function. and the run functional implementation so that it passes the 
complete input (of type input_state) to the tick function.  Instead of:
```
let primitives : Primitives.t list = tick_f t screen input.keys in
```
It should change it to:
```
let primitives : Primitives.t list = tick_f t screen input in
```