### PR TITLE
Fix issue 83

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ $ cd ..
 $ git submodule update --init --recursive
 ```
 
+## Standard keys
+
+Mostly Claudius doesn't have any interaction points beyond those you provide, but there are a few:
+
+* F2 - Save a screenshot to a GIF
+
 # Docs
 
 There are [odoc](https://github.com/ocaml/odoc) documentation for most of Claudius. You can build that documentation with:

--- a/src/base.ml
+++ b/src/base.ml
@@ -124,6 +124,8 @@ let run title boot tick s =
              } in
              if exit then ()
              else begin
+               Screenshot.save_screenshot current_input.events s prev_buffer;
+
                let updated_buffer = tick t s prev_buffer current_input in
                if (updated_buffer != prev_buffer)
                   || (Framebuffer.is_dirty updated_buffer)

--- a/src/screenshot.ml
+++ b/src/screenshot.ml
@@ -56,7 +56,7 @@ let capture_screenshot (screen : Screen.t) (fb : Framebuffer.t) =
       let y = idx / scaled_width in
       let src_x = x / scale in
       let src_y = y / scale in
-      let v = 
+      let v =
         match Framebuffer.pixel_read src_x src_y fb with
         | Some v -> v
         | None -> failwith (Printf.sprintf "Invalid pixel coordinate (%d,%d)" src_x src_y) in
@@ -83,17 +83,16 @@ let capture_screenshot (screen : Screen.t) (fb : Framebuffer.t) =
   GIF.to_file gif filename;
   Printf.printf "Screenshot saved as %s\n%!" filename
 
-let has_saved = ref false
+let save_screenshot (events : Event.t list) (screen : Screen.t) (fb : Framebuffer.t) =
 
-let save_screenshot (keys : Key.t list) (screen : Screen.t) (fb : Framebuffer.t) =
+  let take_screenshot = List.fold_left (fun acc ev ->
+    match ev with
+    | Event.KeyDown Key.F2 -> true
+    | _ -> acc
+  ) false events in
 
-  if Palette.size (Screen.palette screen) > 256 then
-    failwith "GIF only supports up to 256 colors";
-
-  let f2_down = List.mem Key.F2 keys in
-  if f2_down && not !has_saved then (
+  if take_screenshot then (
+    if Palette.size (Screen.palette screen) > 256 then
+      failwith "GIF only supports up to 256 colors";
     capture_screenshot screen fb;
-    has_saved := true
-  ) else if not f2_down then (
-    has_saved := false
   )

--- a/src/screenshot.mli
+++ b/src/screenshot.mli
@@ -1,7 +1,6 @@
 (** Module for handling screenshots *)
 
-val save_screenshot : Key.t list -> Screen.t -> Framebuffer.t -> unit
-(** [save_screenshot keys screen framebuffer] saves a screenshot  with a timestamped filename 
+val save_screenshot : Event.t list -> Screen.t -> Framebuffer.t -> unit
+(** [save_screenshot keys screen framebuffer] saves a screenshot  with a timestamped filename
     like "screenshot_DDMMYY_HHMMSS.gif" for uniqueness. The output image is scaled by screen's scale factor factor
     Prevents multiple screenshots if F2 is held down. *)
-    

--- a/test/test_screenshot.ml
+++ b/test/test_screenshot.ml
@@ -17,24 +17,32 @@ let test_palette name palette =
 
     Framebuffer.set_dirty fb;
     let screen = Screen.create width height scale palette in
-    Screenshot.save_screenshot [Key.F2] screen fb
+    Screenshot.save_screenshot [(Event.KeyDown Key.F2)] screen fb
   )
 
 let test_palette_too_big _ =
-  let palette = Palette.generate_mono_palette 300 in          (* > 256 entries *) 
+  let palette = Palette.generate_mono_palette 300 in          (* > 256 entries *)
   let fb = Framebuffer.init (width, height) (fun _ _ -> 42) in
   Framebuffer.set_dirty fb;
   let screen = Screen.create width height scale palette in
   assert_raises
     (Failure "GIF only supports up to 256 colors")
-    (fun () -> Screenshot.save_screenshot [Key.F2] screen fb)
+    (fun () -> Screenshot.save_screenshot [(Event.KeyDown Key.F2)] screen fb)
+
+let test_palette_too_big_no_press _ =
+  let palette = Palette.generate_mono_palette 300 in          (* > 256 entries *)
+  let fb = Framebuffer.init (width, height) (fun _ _ -> 42) in
+  Framebuffer.set_dirty fb;
+  let screen = Screen.create width height scale palette in
+  Screenshot.save_screenshot [] screen fb
 
 let () =
 let suite = "screenshot_tests" >::: [
   test_palette "vapourwave" (Palette.generate_vapourwave_palette 64);
   test_palette "vga" (Palette.generate_microsoft_vga_palette ());
   test_palette "monopalette" (Palette.generate_mono_palette 256);
-  "raises error when palette exceeds 256 colors" >:: test_palette_too_big;        
+  "raises error when palette exceeds 256 colors" >:: test_palette_too_big;
+  "raises error when palette exceeds 256 colors no press" >:: test_palette_too_big_no_press;
 ] in
 
 run_test_tt_main suite;


### PR DESCRIPTION
This addresses issue #83 whereby the screenshot code accidentally caused Claudius to exit if you used more than 256 colours, even if you never took a screenshot.

In this PR:

* Moved the guard for 256 colours until after the guard for the keypress, not before it
* Moved the keypress check to use the new events system, removing internal state from the screenshot code that made testing awkward
* Added a new test case for the failure case to test_screenshots
* Added a note about pressing F2 to the readme.