### PR TITLE
Enhanced debug screen

### DIFF
--- a/src/base.ml
+++ b/src/base.ml
@@ -171,7 +171,7 @@ let run title boot tick s =
 
               let updated_buffer = tick t s prev_buffer current_input in
 
-              if !show_stats then Stats.render !fps_stats s updated_buffer;
+              if !show_stats then Stats.render !fps_stats t s updated_buffer;
 
               if
                 updated_buffer != prev_buffer

--- a/src/base.ml
+++ b/src/base.ml
@@ -171,14 +171,17 @@ let run title boot tick s =
 
               let updated_buffer = tick t s prev_buffer current_input in
 
-              if !show_stats then Stats.render !fps_stats t s updated_buffer;
+              let display_buffer =
+                if !show_stats then Stats.render !fps_stats t s updated_buffer
+                else updated_buffer
+              in
 
               if
-                updated_buffer != prev_buffer
-                || Framebuffer.is_dirty updated_buffer
+                display_buffer != prev_buffer
+                || Framebuffer.is_dirty display_buffer
                 || Screen.is_dirty s
               then (
-                framebuffer_to_bigarray s updated_buffer bitmap;
+                framebuffer_to_bigarray s display_buffer bitmap;
                 (match render_texture r texture s bitmap with
                 | Error (`Msg e) -> Sdl.log "Render error: %s" e
                 | Ok () -> ());

--- a/src/stats.ml
+++ b/src/stats.ml
@@ -14,6 +14,7 @@ let update ~now ~tick previous =
   else previous
 
 let render fps_stats tick screen framebuffer =
+  let framebuffer = Framebuffer.map (fun i -> i) framebuffer in
   let width, height = Screen.dimensions screen
   and font = Screen.font screen
   and colour_count = Palette.size (Screen.palette screen) in
@@ -56,4 +57,6 @@ let render fps_stats tick screen framebuffer =
       (i mod columns * 10)
       (offset + (i / columns * 10))
       10 10 i framebuffer
-  done
+  done;
+
+  framebuffer

--- a/src/stats.ml
+++ b/src/stats.ml
@@ -13,19 +13,37 @@ let update ~now ~tick previous =
     }
   else previous
 
-let render fps_stats screen framebuffer =
-  let width, height = Screen.dimensions screen and font = Screen.font screen in
+let render fps_stats tick screen framebuffer =
+  let width, height = Screen.dimensions screen
+  and font = Screen.font screen
+  and colour_count = Palette.size (Screen.palette screen) in
 
-  let fps_text = Printf.sprintf "FPS: %d" fps_stats.average_fps in
-  let res_text = Printf.sprintf "RES: %dx%d" width height in
+  let info =
+    [
+      ("Tick:", string_of_int tick);
+      ("FPS:", string_of_int fps_stats.average_fps);
+      ("Resolution:", Printf.sprintf "%dx%d" width height);
+      ("Colours:", string_of_int colour_count);
+    ]
+  in
 
-  let base_x = 4 in
-  let base_y = 4 in
+  let max_key_width =
+    List.fold_left
+      (fun acc (k, _) ->
+        let width =
+          Framebuffer.draw_string (-1000) (-1000) font k 0 framebuffer
+        in
+        if width > acc then width else acc)
+      0 info
+  in
 
-  let palette_max = Palette.size (Screen.palette screen) - 1 in
+  let palette_max = colour_count - 1 in
 
-  ignore
-    (Framebuffer.draw_string base_x base_y font fps_text palette_max framebuffer);
-  ignore
-    (Framebuffer.draw_string base_x (base_y + 14) font res_text palette_max
-       framebuffer)
+  List.iteri
+    (fun i (k, v) ->
+      let y_offset = 4 + (14 * i) in
+      ignore (Framebuffer.draw_string 4 y_offset font k palette_max framebuffer);
+      ignore
+        (Framebuffer.draw_string (max_key_width + 10) y_offset font v
+           palette_max framebuffer))
+    info

--- a/src/stats.ml
+++ b/src/stats.ml
@@ -46,4 +46,14 @@ let render fps_stats tick screen framebuffer =
       ignore
         (Framebuffer.draw_string (max_key_width + 10) y_offset font v
            palette_max framebuffer))
-    info
+    info;
+
+  let columns = width / 10 in
+  let rows = (palette_max / columns) + 1 in
+  let offset = height - (10 * rows) in
+  for i = 0 to palette_max do
+    Framebuffer.filled_rect
+      (i mod columns * 10)
+      (offset + (i / columns * 10))
+      10 10 i framebuffer
+  done

--- a/src/stats.mli
+++ b/src/stats.mli
@@ -11,5 +11,5 @@ val fps : t -> int
 val update : now:float -> tick:int -> t -> t
 (** Calculate the updated stats based on current time/tick *)
 
-val render : t -> Screen.t -> Framebuffer.t -> unit
+val render : t -> int -> Screen.t -> Framebuffer.t -> unit
 (** Draw stats on the provided framebuffer *)

--- a/src/stats.mli
+++ b/src/stats.mli
@@ -11,5 +11,5 @@ val fps : t -> int
 val update : now:float -> tick:int -> t -> t
 (** Calculate the updated stats based on current time/tick *)
 
-val render : t -> int -> Screen.t -> Framebuffer.t -> unit
+val render : t -> int -> Screen.t -> Framebuffer.t -> Framebuffer.t
 (** Draw stats on the provided framebuffer *)


### PR DESCRIPTION
This PR does the following:

* Adds a little more text info to the debug screen and tidies up the layout
* Displays the palette on the debug screen (fixes #92)
* Fixes a bug whereby the debug overlay was committed to the framebuffer retuned to the tick function

The last one is a little embarrassing, as I failed to spot this in review of the original PR, but when we get the framebuffer from the tick function and overlay the debug information on it, we modify the framebuffer returned to the next iterations tick function: this is both clearly wrong (the tick function should always get back the framebuffer it last returned), and if the tick functions doesn't do any updates the overlay information keeps drawing over itself to become unreadable. The fix was to make the stats function return a new framebuffer that is displayed and then discarded, so the framebuffer made by the tick function is never modified and can be returned to it on the next iteration,