### PR TITLE
Flags modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Mostly Claudius doesn't have any interaction points beyond those you provide, bu
 
 * F1 - Show debug overlay
 * F2 - Save a screenshot to a GIF
+* F3 - Save an animation to a GIF
 
 # Docs
 

--- a/claudius.opam
+++ b/claudius.opam
@@ -22,14 +22,14 @@ homepage: "https://github.com/claudiusFX/claudius"
 doc: "https://github.com/claudiusFX/claudius"
 bug-reports: "https://github.com/claudiusFX/claudius/issues"
 depends: [
-  "ocaml"
+  "ocaml" {>= "5.1"}
   "dune" {>= "3.17"}
   "tsdl"
-  "ounit2"
-  "odoc"
+  "ounit2" {with-test}
+  "odoc" {with-doc}
   "giflib"
   "crunch"
-  "ocamlformat"
+  "ocamlformat" {>= "0.27.0" & with-dev-setup}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/dune-project
+++ b/dune-project
@@ -19,7 +19,7 @@
  (name claudius)
  (synopsis "A retro-style graphics library")
  (description "An functional style retro-graphics library for OCaml for building generative art, demos, and games.")
- (depends ocaml dune tsdl ounit2 odoc giflib crunch ocamlformat)
+ (depends (ocaml (>= 5.1)) dune tsdl (ounit2 :with-test) (odoc :with-doc) giflib crunch (ocamlformat (and (>= 0.27.0) :with-dev-setup )))
  (tags
   (graphics rendering paletted)))
 


### PR DESCRIPTION
The flags were originally added to opam manually. Now they are being added to dune-project so as to auto generate them in the opam file on every dune build. 

Flags added: {with-dev-setup}, {with-doc}, {with-test}

Also, the animation shortcut F3 has been added in readme.