### PR TITLE
[Fix]: The license had a typo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Install requirements
         run: sudo apt install -y libsdl2-dev
 
-      - name: Install dune
-        run: opam install dune
+      - name: Install dune and ocamlformat
+        run: opam install dune ocamlformat
 
       - name: Get packages
         run: opam exec -- dune pkg lock

--- a/claudius.opam
+++ b/claudius.opam
@@ -16,7 +16,7 @@ authors: [
   "Vanisha1606 <vanishag1606@gmail.com>"
   "Wah Vanessa <wahvanessa22@gmail.com>"
 ]
-license: "ICS"
+license: "ISC"
 tags: ["graphics" "rendering" "paletted"]
 homepage: "https://github.com/claudiusFX/claudius"
 doc: "https://github.com/claudiusFX/claudius"

--- a/dune-project
+++ b/dune-project
@@ -11,7 +11,7 @@
 
 (maintainers "Michael Dales <michael@digitalflapjack.com>" "Shreya Pawaskar <shreya.pawaskar.main@gmail.com>")
 
-(license ICS)
+(license ISC)
 
 (documentation https://github.com/claudiusFX/claudius)
 


### PR DESCRIPTION
Fixed the license typo from ICS to ISC which was causing error in the opam publish on local checks. 