### PR TITLE
Remove int masks that don't work on 32 bit that are also unnecessary

### DIFF
--- a/src/font.ml
+++ b/src/font.ml
@@ -156,12 +156,10 @@ let of_file filename =
 
 let print_header (font : t) =
   let header = font.header in
-  Printf.printf "Magic:            0x%08x\n"
-    (Int32.to_int header.magic land 0xFFFFFFFF);
+  Printf.printf "Magic:            0x%08x\n" (Int32.to_int header.magic);
   Printf.printf "Version:          %d\n" (Int32.to_int header.version);
   Printf.printf "Header Size:      %d\n" (Int32.to_int header.headersize);
-  Printf.printf "Flags:            0x%08x\n"
-    (Int32.to_int header.flags land 0xFFFFFFFF);
+  Printf.printf "Flags:            0x%08x\n" (Int32.to_int header.flags);
   Printf.printf "Number of Glyphs: %d\n" (Int32.to_int header.number_of_glyphs);
   Printf.printf "Bytes per Glyph:  %d\n" (Int32.to_int header.bytes_per_glyph);
   Printf.printf "Width:            %d\n" (Int32.to_int header.width);


### PR DESCRIPTION
For some reason I decided to apply a 0xFFFFFFFF mask to a 32 bit integer value, which is a bit redundant, particularly with the print format mask. Removing as this causes 32bit builds to fail